### PR TITLE
Make the CLI extensible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ pub mod cli;
 pub mod encryption;
 pub mod events;
 pub mod hd;
-mod io;
+pub mod io;
 pub mod loader;
 pub mod persistence;
 pub mod reader;


### PR DESCRIPTION
* Add a trait method `CLI::extra_commands`, which is empty by
  default but can be overridden to return a list of network-specific
  commands
* Export types and functions to aid in developing new commands from
  other crates