### PR TITLE
Re-export crates which form part of this crate's interface.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3481,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "tagged-base64"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/tagged-base64.git?branch=main#5295fafb4068c67e271b831a00cd80846a2fd512"
+source = "git+https://github.com/EspressoSystems/tagged-base64?branch=main#5295fafb4068c67e271b831a00cd80846a2fd512"
 dependencies = [
  "base64 0.13.0",
  "console_error_panic_hook",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ pub mod testing;
 pub mod txn_builder;
 
 pub use crate::asset_library::{AssetInfo, MintInfo};
+pub use jf_cap;
+pub use reef;
 
 use crate::{
     asset_library::AssetLibrary,


### PR DESCRIPTION
I am hoping this will make rustdoc links to [jf_cap] and [reef]
work correctly.