### PR TITLE
Add transaction kind to Memos event.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,9 +2826,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3508,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "tagged-base64"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/tagged-base64?branch=main#5295fafb4068c67e271b831a00cd80846a2fd512"
+source = "git+https://github.com/EspressoSystems/tagged-base64.git?branch=main#5295fafb4068c67e271b831a00cd80846a2fd512"
 dependencies = [
  "base64 0.13.0",
  "console_error_panic_hook",

--- a/src/events.rs
+++ b/src/events.rs
@@ -51,7 +51,7 @@ pub enum LedgerEvent<L: Ledger> {
     /// included in `transaction`.
     Memos {
         outputs: Vec<(ReceiverMemo, RecordCommitment, u64, MerklePath)>,
-        transaction: Option<(u64, u64)>,
+        transaction: Option<(u64, u64, TransactionKind<L>)>,
     },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -726,13 +726,6 @@ pub trait WalletBackend<'a, L: Ledger>: Send {
         nullifier: Nullifier,
     ) -> Result<(bool, NullifierProof<L>), WalletError<L>>;
 
-    /// Get the specified transaction from the specified block.
-    async fn get_transaction(
-        &self,
-        block_id: u64,
-        txn_id: u64,
-    ) -> Result<Transaction<L>, WalletError<L>>;
-
     /// Submit a transaction to a validator.
     async fn submit(
         &mut self,
@@ -1041,7 +1034,13 @@ impl<'a, L: 'static + Ledger> WalletState<'a, L> {
                     .extend(outputs.iter().map(|(memo, _, uid, _)| (memo.clone(), *uid)));
                 for key_pair in self.user_keys.values().cloned().collect::<Vec<_>>() {
                     let records = self
-                        .try_open_memos(session, &key_pair, &outputs, transaction, !self_published)
+                        .try_open_memos(
+                            session,
+                            &key_pair,
+                            &outputs,
+                            transaction.clone(),
+                            !self_published,
+                        )
                         .await;
                     if let Err(err) = self.add_records(session, &key_pair, records).await {
                         println!("error saving received records: {}", err);
@@ -1165,7 +1164,7 @@ impl<'a, L: 'static + Ledger> WalletState<'a, L> {
         session: &mut WalletSession<'a, L, impl WalletBackend<'a, L>>,
         key_pair: &UserKeyPair,
         memos: &[(ReceiverMemo, RecordCommitment, u64, MerklePath)],
-        transaction: Option<(u64, u64)>,
+        transaction: Option<(u64, u64, TransactionKind<L>)>,
         add_to_history: bool,
     ) -> Vec<(RecordOpening, u64, MerklePath)> {
         let mut records = Vec::new();
@@ -1180,21 +1179,7 @@ impl<'a, L: 'static + Ledger> WalletState<'a, L> {
         }
 
         if add_to_history && !records.is_empty() {
-            if let Some((block_id, txn_id)) = transaction {
-                // To add a transaction history entry, we need to fetch the actual transaction to
-                // figure out what type it was.
-                let kind = match session.backend.get_transaction(block_id, txn_id).await {
-                    Ok(txn) => txn.kind(),
-                    Err(err) => {
-                        println!(
-                            "Error fetching received transaction ({}, {}) from network: {}. \
-                                Transaction will be recorded with unknown type.",
-                            block_id, txn_id, err
-                        );
-                        TransactionKind::<L>::unknown()
-                    }
-                };
-
+            if let Some((block_id, txn_id, kind)) = transaction {
                 self.add_receive_history(
                     session,
                     block_id,


### PR DESCRIPTION
This avoids the need to make a network call to get the tranasction
kind every time we receive a transaction.

See #70