### PR TITLE
Support verified assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3034,6 +3034,7 @@ dependencies = [
  "serde",
  "sha3 0.9.1",
  "snafu 0.6.10",
+ "structopt",
  "strum",
  "strum_macros",
  "surf",
@@ -3508,7 +3509,7 @@ dependencies = [
 [[package]]
 name = "tagged-base64"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/tagged-base64?branch=main#5295fafb4068c67e271b831a00cd80846a2fd512"
+source = "git+https://github.com/EspressoSystems/tagged-base64.git?branch=main#5295fafb4068c67e271b831a00cd80846a2fd512"
 dependencies = [
  "base64 0.13.0",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ rustyline = "9.0.0"
 serde = { version = "1.0", features = ["derive"] }
 sha3 = "^0.9"
 snafu = { version = "0.6.10", features = ["backtraces"] }
+structopt = "0.3"
 strum = "0.20"
 strum_macros = "0.20.1"
 surf = "2.3.1"

--- a/src/asset_library.rs
+++ b/src/asset_library.rs
@@ -339,6 +339,14 @@ impl From<AssetLibrary> for Vec<AssetInfo> {
     }
 }
 
+impl IntoIterator for AssetLibrary {
+    type Item = AssetInfo;
+    type IntoIter = <Vec<AssetInfo> as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.assets.into_iter()
+    }
+}
+
 impl FromIterator<AssetInfo> for AssetLibrary {
     fn from_iter<T: IntoIterator<Item = AssetInfo>>(iter: T) -> Self {
         iter.into_iter().collect::<Vec<_>>().into()

--- a/src/asset_library.rs
+++ b/src/asset_library.rs
@@ -5,9 +5,24 @@
 // This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+//! Collections of and information on CAP assets.
+//!
+//! This module defines [AssetInfo] and [MintInfo], which store auxiliary information about assets
+//! which is useful to wallets but not present in [AssetDefinition]. For example, [AssetInfo] may
+//! include a [MintInfo], which contains the secret information needed by the asset creator to mint
+//! more of that asset type.
+//!
+//! This module also defines an interface for verified asset types, [VerifiedAssetLibrary]. This is
+//! a collection of assets which can be signed by a trusted party, such as an application developer,
+//! and distributed to client applications. Applications with verified status can thus be displayed
+//! as such, for example by including a badge in a GUI application. Note that this library merely
+//! provides the mechanisms and interfaces for creating and consuming verified asset libraries. It
+//! does not define any specific libraries or verification keys, as these are application-specific
+//! and thus should be defined in clients of this crate.
 use jf_cap::{
     keys::AuditorPubKey,
     structs::{AssetCode, AssetCodeSeed, AssetDefinition},
+    BaseField, KeyPair, Signature, VerKey,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -20,8 +35,16 @@ use tagged_base64::TaggedBase64;
 /// Details about an asset type.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AssetInfo {
+    /// CAP asset definition.
     pub definition: AssetDefinition,
+    /// Secret information required to mint an asset.
     pub mint_info: Option<MintInfo>,
+    /// This asset is included in a [VerifiedAssetLibrary].
+    pub verified: bool,
+    /// This asset is not included in the persistent asset library.
+    ///
+    /// It will need to be reloaded when the wallet is restarted.
+    pub temporary: bool,
 }
 
 impl AssetInfo {
@@ -29,26 +52,46 @@ impl AssetInfo {
         Self {
             definition,
             mint_info: Some(mint_info),
+            verified: false,
+            temporary: false,
+        }
+    }
+
+    fn verified(definition: AssetDefinition) -> Self {
+        Self {
+            definition,
+            // Verified assets are meant to be distributed. We should never distribute mint info.
+            mint_info: None,
+            verified: true,
+            // Assets loaded from verified libraries are not included in our persistent state.
+            // Instead, they should be loaded from the verified library each time the wallet is
+            // launched, in case the verified library changes.
+            //
+            // Note that if the same asset is imported manually, it will be persisted due to the
+            // semantics of [AssetInfo::update] with respect to `temporary`, but upon being loaded
+            // it will be marked unverified until the verified library containing it is reloaded.
+            temporary: true,
         }
     }
 
     /// Details about the native asset type.
     pub fn native() -> Self {
-        Self {
-            definition: AssetDefinition::native(),
-            mint_info: None,
-        }
+        Self::from(AssetDefinition::native())
     }
 
     /// Update this info by merging in information from `info`.
     ///
     /// * `self.definition` is replaced with `info.definition`
     /// * If `info.mint_info` exists, it replaces `self.mint_info`
+    /// * `self.temporary` is `true` only if both `self` and `info` are temporary
+    /// * `self.verified` is `true` if either `self` or `info` is verified
     pub fn update(&mut self, info: AssetInfo) {
         self.definition = info.definition;
         if let Some(mint_info) = info.mint_info {
             self.mint_info = Some(mint_info);
         }
+        self.temporary &= info.temporary;
+        self.verified |= info.verified;
     }
 }
 
@@ -57,6 +100,8 @@ impl From<AssetDefinition> for AssetInfo {
         Self {
             definition,
             mint_info: None,
+            verified: false,
+            temporary: false,
         }
     }
 }
@@ -69,9 +114,14 @@ impl Display for AssetInfo {
                 f,
                 ",seed:{},description:{}",
                 mint_info.seed,
-                mint_info.fmt_description()
+                mint_info.fmt_description(),
             )?;
         }
+        write!(
+            f,
+            ",verified:{},temporary:{}",
+            self.verified, self.temporary
+        )?;
         Ok(())
     }
 }
@@ -82,11 +132,16 @@ impl FromStr for AssetInfo {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // This parse method is meant for a friendly, discoverable CLI interface. It parses a comma-
         // separated list of key-value pairs, like `description:my_asset`. This allows the fields to
-        // be specified in any order, or not at all. Recognized fields are "description", "seed",
-        // and "definition".
+        // be specified in any order, or not at all.
+        //
+        // Recognized fields are "description", "seed", "definition", and "temporary". Note that the
+        // `verified` field cannot be set this way. There is only one way to create verified
+        // `AssetInfo`: using [Wallet::verify_assets], which performs a signature check before
+        // marking assets verified.
         let mut definition = None;
         let mut seed = None;
         let mut description = None;
+        let mut temporary = false;
         for kv in s.split(',') {
             let (key, value) = match kv.split_once(':') {
                 Some(split) => split,
@@ -108,6 +163,11 @@ impl FromStr for AssetInfo {
                     )
                 }
                 "description" => description = Some(MintInfo::parse_description(value)),
+                "temporary" => {
+                    temporary = value
+                        .parse()
+                        .map_err(|_| format!("expected bool, got {}", value))?
+                }
                 _ => return Err(format!("unrecognized key {}", key)),
             }
         }
@@ -128,6 +188,8 @@ impl FromStr for AssetInfo {
         Ok(AssetInfo {
             definition,
             mint_info,
+            temporary,
+            verified: false,
         })
     }
 }
@@ -181,6 +243,7 @@ pub struct AssetLibrary {
 }
 
 impl AssetLibrary {
+    /// Create an [AssetLibrary] with the given assets and viewing keys.
     pub fn new(assets: Vec<AssetInfo>, audit_keys: HashSet<AuditorPubKey>) -> Self {
         // Create the library empty so that we can use `insert` to add the assets, which will ensure
         // that all of the data structures (assets, index, and auditable) are populated consistently.
@@ -217,6 +280,10 @@ impl AssetLibrary {
         }
     }
 
+    /// Add a viewing key.
+    ///
+    /// Any assets which were already in the library and can be viewed using this key will be marked
+    /// as viewable.
     pub fn add_audit_key(&mut self, key: AuditorPubKey) {
         // Upon discovering a new audit key, we need to check if any existing assets have now become
         // auditable.
@@ -229,20 +296,34 @@ impl AssetLibrary {
         self.audit_keys.insert(key);
     }
 
+    /// List viewable assets.
     pub fn auditable(&self) -> &HashMap<AssetCode, AssetDefinition> {
         &self.auditable
     }
 
+    /// Iterate over all assets in the library.
     pub fn iter(&self) -> impl Iterator<Item = &AssetInfo> {
         self.assets.iter()
     }
 
+    /// Check if the library contains an asset with the given code.
     pub fn contains(&self, code: AssetCode) -> bool {
         self.index.contains_key(&code)
     }
 
+    /// Get the asset with the given code, if there is one.
     pub fn get(&self, code: AssetCode) -> Option<&AssetInfo> {
         self.index.get(&code).map(|i| &self.assets[*i])
+    }
+
+    /// The total number of assets in the library.
+    pub fn len(&self) -> usize {
+        self.assets.len()
+    }
+
+    /// Returns `true` if and only if there are no assets in the library.
+    pub fn is_empty(&self) -> bool {
+        self.assets.is_empty()
     }
 }
 
@@ -269,5 +350,74 @@ impl Index<AssetCode> for AssetLibrary {
 
     fn index(&self, code: AssetCode) -> &AssetInfo {
         self.get(code).unwrap()
+    }
+}
+
+/// A library of assets, signed by a trusted party.
+///
+/// The creation, distribution, and consumption of verified asset libraries should go roughly as
+/// follows:
+/// 1. An application developer creates a [KeyPair] which will be used to sign asset libraries meant
+///    for their application. They store the [KeyPair] containing the private signing key in a
+///    secure, private location. The `gen_signing_key` executable that ships with this crate can be
+///    used to do this.
+/// 2. The application developer creates a [VerifiedAssetLibrary] using their new signing key and
+///    writes it to a file (for example, using [bincode] serialization). The
+///    `gen_verified_asset_library` executable that ships with this crate can be used to do this.
+/// 3. The application developer distributes this file to users along with the client application.
+/// 4. The application, upon creating a [Wallet](crate::Wallet), deserializes the
+///    [VerifiedAssetLibrary] and calls [Wallet::verify_assets](crate::Wallet::verify_assets) with
+///    the public key from step 1. This key can be hard-coded in the client application.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct VerifiedAssetLibrary {
+    // The public key which was used to sign this library (for inspection purposes).
+    signer: VerKey,
+    signature: Signature,
+    assets: Vec<AssetInfo>,
+}
+
+impl VerifiedAssetLibrary {
+    /// Create and sign a new verified asset library.
+    pub fn new(assets: impl IntoIterator<Item = AssetDefinition>, signer: &KeyPair) -> Self {
+        let assets = assets
+            .into_iter()
+            .map(AssetInfo::verified)
+            .collect::<Vec<_>>();
+        Self {
+            signer: signer.ver_key(),
+            signature: signer.sign(&[Self::digest(&assets)]),
+            assets,
+        }
+    }
+
+    /// Obtain a list of the assets in `self`, but only if `self` is signed by `trusted_signer`.
+    pub fn open(self, trusted_signer: &VerKey) -> Option<Vec<AssetInfo>> {
+        if self.check() == Some(trusted_signer.clone()) {
+            Some(self.assets)
+        } else {
+            None
+        }
+    }
+
+    /// Check that the library is correctly signed and return the public key used to sign it.
+    pub fn check(&self) -> Option<VerKey> {
+        if self
+            .signer
+            .verify(&[Self::digest(&self.assets)], &self.signature)
+            .is_ok()
+        {
+            Some(self.signer.clone())
+        } else {
+            None
+        }
+    }
+
+    fn digest(assets: &[AssetInfo]) -> BaseField {
+        let bytes = assets
+            .iter()
+            .map(|asset| bincode::serialize(asset).unwrap())
+            .flatten()
+            .collect::<Vec<_>>();
+        jf_utils::hash_to_field(bytes)
     }
 }

--- a/src/bin/check_verified_asset_library.rs
+++ b/src/bin/check_verified_asset_library.rs
@@ -1,0 +1,51 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the Seahorse library.
+
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use seahorse::asset_library::VerifiedAssetLibrary;
+use std::fs::read;
+use std::io;
+use std::path::PathBuf;
+use std::process::exit;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+#[structopt(
+    name = "check_verified_asset_library",
+    about = "Check that a verified asset library is correctly signed and print its contents."
+)]
+struct Options {
+    /// Only check the validity of the library, do not print its contents.
+    #[structopt(short, long)]
+    check: bool,
+
+    /// The library to check.
+    library: PathBuf,
+}
+
+fn main() -> io::Result<()> {
+    let opt = Options::from_args();
+    let bytes = read(opt.library)?;
+    let library = match bincode::deserialize::<VerifiedAssetLibrary>(&bytes) {
+        Ok(library) => library,
+        Err(err) => {
+            eprintln!("Malformed library: {}", err);
+            exit(1);
+        }
+    };
+    if let Some(signer) = library.check() {
+        if !opt.check {
+            println!("Signed by {}", signer);
+            for asset in library.open(&signer).unwrap() {
+                println!("{}", asset);
+            }
+        }
+        Ok(())
+    } else {
+        eprintln!("Library is not properly signed.");
+        exit(1);
+    }
+}

--- a/src/bin/gen_signing_key.rs
+++ b/src/bin/gen_signing_key.rs
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the Seahorse library.
+
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use ark_serialize::CanonicalSerialize;
+use jf_cap::KeyPair;
+use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
+use tagged_base64::TaggedBase64;
+
+fn main() {
+    let mut rng = ChaChaRng::from_entropy();
+    let key_pair = KeyPair::generate(&mut rng);
+
+    // `KeyPair` doesn't have a `tagged_blob` attribute, so we have to manually convert the key to
+    // bytes and then to tagged base 64 for printing.
+    let mut bytes = vec![];
+    key_pair.serialize(&mut bytes).unwrap();
+    let private = TaggedBase64::new("SIGNKEY", &bytes).unwrap();
+
+    println!("Public key: {}", key_pair.ver_key_ref());
+    println!("Private key: {}", private);
+}

--- a/src/bin/gen_verified_asset_library.rs
+++ b/src/bin/gen_verified_asset_library.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the Seahorse library.
+
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use ark_serialize::CanonicalDeserialize;
+use jf_cap::{structs::AssetDefinition, KeyPair};
+use seahorse::asset_library::VerifiedAssetLibrary;
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::exit;
+use std::str::FromStr;
+use structopt::StructOpt;
+use tagged_base64::TaggedBase64;
+
+#[derive(StructOpt)]
+#[structopt(
+    name = "gen_verified_asset_library",
+    about = "Generate and sign asset libraries."
+)]
+struct Options {
+    /// Include the native asset in the library even if it is not explicitly an input.
+    #[structopt(short = "n", long)]
+    include_native: bool,
+
+    /// Include asset definitions in the library by reading them from IN (separated by newlines).
+    #[structopt(short, long, name = "IN")]
+    input: Vec<PathBuf>,
+
+    /// Write the library to OUT.
+    #[structopt(short, long, name = "OUT")]
+    output: PathBuf,
+
+    /// The signing key to use when authenticating the library.
+    #[structopt(short, long)]
+    key: String,
+
+    /// Optional list of assets to include, passed on the command line rather than using --input.
+    assets: Vec<AssetDefinition>,
+}
+
+fn main() -> io::Result<()> {
+    let mut opt = Options::from_args();
+    let key = match TaggedBase64::parse(&opt.key) {
+        Ok(tb64) => match KeyPair::deserialize(tb64.value().as_slice()) {
+            Ok(key) => key,
+            Err(err) => {
+                eprintln!("Invalid key: {}", err);
+                exit(1);
+            }
+        },
+        Err(err) => {
+            eprintln!("Invalid key: {}", err);
+            exit(1);
+        }
+    };
+
+    // Collect assets from 3 possible sources:
+    // 	* --include-native, if specified
+    // 	* input files given on the command line
+    // 	* literal assets given on the command line
+    let mut assets = vec![];
+    if opt.include_native {
+        assets.push(AssetDefinition::native());
+    }
+    for path in opt.input {
+        let file = BufReader::new(File::open(&path)?);
+        for line in file.lines() {
+            let line = line?;
+            let asset = match AssetDefinition::from_str(&line) {
+                Ok(asset) => asset,
+                Err(err) => {
+                    eprintln!("invalid asset {} in file {:?}: {}", line, path, err);
+                    exit(1);
+                }
+            };
+            assets.push(asset);
+        }
+    }
+    assets.append(&mut opt.assets);
+
+    // Generate and sign the library.
+    let library = VerifiedAssetLibrary::new(assets, &key);
+
+    // Write the library to the output file.
+    let mut file = File::create(opt.output)?;
+    file.write_all(&bincode::serialize(&library).unwrap())?;
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! Users should also be familiar with [reef], which provides traits to adapt a particular CAP
 //! ledger to the ledger-agnostic interfaces defined here.
-mod asset_library;
+pub mod asset_library;
 pub mod cli;
 pub mod encryption;
 pub mod events;
@@ -37,7 +37,7 @@ pub use jf_cap;
 pub use reef;
 
 use crate::{
-    asset_library::AssetLibrary,
+    asset_library::{AssetLibrary, VerifiedAssetLibrary},
     events::{EventIndex, EventSource, LedgerEvent},
     txn_builder::*,
 };
@@ -67,7 +67,7 @@ use jf_cap::{
         AssetCode, AssetDefinition, AssetPolicy, FreezeFlag, Nullifier, ReceiverMemo,
         RecordCommitment, RecordOpening,
     },
-    KeyPair as SigKeyPair, MerkleLeafProof, MerklePath, Signature, TransactionNote,
+    KeyPair as SigKeyPair, MerkleLeafProof, MerklePath, Signature, TransactionNote, VerKey,
 };
 use key_set::ProverKeySet;
 use rand_chacha::rand_core::SeedableRng;
@@ -150,6 +150,8 @@ pub enum WalletError<L: Ledger> {
     UserKeyExists {
         pub_key: UserPubKey,
     },
+    /// Attempted to load an asset library with an invalid signature.
+    AssetVerificationError,
     #[snafu(display("{}", msg))]
     Failed {
         msg: String,
@@ -546,6 +548,11 @@ impl<'a, 'l, L: Ledger, Backend: WalletBackend<'a, L> + ?Sized>
     }
 
     async fn store_asset(&mut self, asset: &AssetInfo) -> Result<(), WalletError<L>> {
+        // We should never mark assets as verified in persistent storage. The single source of truth
+        // for verified assets is a verified asset library loaded independently from our own
+        // persistent storage.
+        assert!(!asset.verified);
+
         if !self.cancelled {
             let res = self.storage().await.store_asset(asset).await;
             if res.is_err() {
@@ -1484,13 +1491,13 @@ impl<'a, L: 'static + Ledger> WalletState<'a, L> {
             let (seed, definition) =
                 self.txn_state
                     .define_asset(&mut session.rng, description, policy)?;
-            let asset = AssetInfo {
+            let asset = AssetInfo::new(
                 definition,
-                mint_info: Some(MintInfo {
+                MintInfo {
                     seed,
                     description: description.to_vec(),
-                }),
-            };
+                },
+            );
 
             // Persist the change that we're about to make before updating our in-memory state. We
             // can't report success until we know the new asset has been saved to disk (otherwise we
@@ -2315,6 +2322,37 @@ impl<'a, L: 'static + Ledger, Backend: 'a + WalletBackend<'a, L> + Send + Sync>
     pub async fn import_asset(&mut self, asset: AssetInfo) -> Result<(), WalletError<L>> {
         let WalletSharedState { state, session, .. } = &mut *self.mutex.lock().await;
         state.import_asset(session, asset).await
+    }
+
+    /// Load a verified asset library from a file or byte stream.
+    ///
+    /// `trusted_signer` must be the public key of an entity trusted by this application to verify
+    /// assets. It must also be the public key which was used to sign `library`.
+    ///
+    /// If successful, the assets loaded from `library` are returned as well as being added to this
+    /// wallet's asset library. Note that assets loaded from a verified library are not persisted
+    /// (unless the same assets are imported as unverified using [Wallet::import_asset]) in order to
+    /// preserve the verified library as the single source of truth about verified assets.
+    /// Therefore, this function must be called each time a wallet is created or opened in order to
+    /// ensure that the verified assets show up in the wallet's library.
+    pub async fn verify_assets(
+        &mut self,
+        trusted_signer: &VerKey,
+        library: VerifiedAssetLibrary,
+    ) -> Result<Vec<AssetInfo>, WalletError<L>> {
+        if let Some(assets) = library.open(trusted_signer) {
+            let WalletSharedState { state, .. } = &mut *self.lock().await;
+            for asset in &assets {
+                // `import_asset` is only for unverified assets. It automatically persists the asset
+                // being imported. We explicitly do not want to persist verified assets (unless
+                // the user explicitly requests persistence by importing the same asset manually) so
+                // all we need to do is add the asset to our in-memory asset library.
+                state.assets.insert(asset.clone());
+            }
+            Ok(assets)
+        } else {
+            Err(WalletError::AssetVerificationError)
+        }
     }
 
     /// Add a viewing key to the wallet's key set.

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -683,10 +683,7 @@ mod tests {
             AssetDefinition::new(AssetCode::random(&mut rng).0, Default::default()).unwrap();
         let audit_key = AuditorKeyPair::generate(&mut rng);
         let freeze_key = FreezerKeyPair::generate(&mut rng);
-        let asset = AssetInfo {
-            definition,
-            mint_info: None,
-        };
+        let asset = AssetInfo::from(definition);
         stored.assets.insert(asset.clone());
         stored.assets.add_audit_key(audit_key.pub_key());
         stored

--- a/src/testing/tests.rs
+++ b/src/testing/tests.rs
@@ -32,6 +32,7 @@ impl<L: Ledger> PartialEq<Self> for TxnHistoryWithTimeTolerantEq<L> {
 pub mod generic_wallet_tests {
     use super::*;
     use async_std::task::block_on;
+    use jf_cap::KeyPair;
     use proptest::{collection::vec, strategy::Strategy, test_runner, test_runner::TestRunner};
     use std::iter::once;
 
@@ -1649,5 +1650,156 @@ pub mod generic_wallet_tests {
             get_asset(imported_asset.code).await,
             AssetInfo::from(imported_asset.clone())
         );
+    }
+
+    #[async_std::test]
+    pub async fn test_verified_assets<'a, T: SystemUnderTest<'a>>() {
+        let mut t = T::default();
+        let mut rng = ChaChaRng::from_seed([37; 32]);
+        let mut now = Instant::now();
+        let initial_grant = 10;
+        let (ledger, mut wallets) = t
+            .create_test_network(&[(2, 2)], vec![initial_grant], &mut now)
+            .await;
+
+        // Discover a non-verified asset so we can later test verifying a non-verified asset.
+        let asset1 = wallets[0]
+            .0
+            .define_asset(&[], AssetPolicy::default())
+            .await
+            .unwrap();
+        {
+            let asset1_info = wallets[0].0.asset(asset1.code).await.unwrap();
+            assert!(!asset1_info.verified);
+            assert!(!asset1_info.temporary);
+        }
+
+        // Now created a verified asset library with 2 assets:
+        // * one that will update `asset1` to be marked verified
+        // * one that does not yet exist in the wallet (later we will import it to check updating
+        //   verified assets with persistence and new information)
+        let key_pair = KeyPair::generate(&mut rng);
+        let (asset2, mint_info2) = {
+            let (code, seed) = AssetCode::random(&mut rng);
+            let definition = AssetDefinition::new(code, AssetPolicy::default()).unwrap();
+            (
+                definition,
+                MintInfo {
+                    seed,
+                    description: vec![],
+                },
+            )
+        };
+        let verified_assets =
+            VerifiedAssetLibrary::new(vec![asset1.clone(), asset2.clone()], &key_pair);
+        let imposter_assets =
+            VerifiedAssetLibrary::new(vec![asset2.clone()], &KeyPair::generate(&mut rng));
+
+        // Import the verified asset library and check that the two expected assets are returned.
+        let imported = wallets[0]
+            .0
+            .verify_assets(key_pair.ver_key_ref(), verified_assets)
+            .await
+            .unwrap();
+        assert_eq!(imported.len(), 2);
+        assert_eq!(
+            imported[0],
+            AssetInfo {
+                definition: asset1.clone(),
+                mint_info: None,
+                verified: true,
+                temporary: true,
+            }
+        );
+        assert_eq!(
+            imported[1],
+            AssetInfo {
+                definition: asset2.clone(),
+                mint_info: None,
+                verified: true,
+                temporary: true,
+            }
+        );
+
+        // Check that importing an asset library signed by an imposter fails.
+        assert!(matches!(
+            wallets[0]
+                .0
+                .verify_assets(key_pair.ver_key_ref(), imposter_assets)
+                .await,
+            Err(WalletError::AssetVerificationError)
+        ));
+
+        // Check that `asset1` got updated, retaining it's mint info and persistence but attaining
+        // verified status.
+        {
+            let asset1_info = wallets[0].0.asset(asset1.code).await.unwrap();
+            assert!(asset1_info.verified);
+            assert!(!asset1_info.temporary);
+            assert_eq!(asset1_info.definition, asset1);
+            assert!(asset1_info.mint_info.is_some());
+        }
+        // Check that `asset2`, which was not present before, got imported as-is.
+        assert_eq!(
+            wallets[0].0.asset(asset2.code).await.unwrap(),
+            AssetInfo {
+                definition: asset2.clone(),
+                mint_info: None,
+                verified: true,
+                temporary: true,
+            }
+        );
+
+        // Check that temporary assets are not persisted, and that persisted assets are never
+        // verified.
+        {
+            let storage = &ledger.lock().await.storage[0];
+            let loaded = storage.lock().await.load().await.unwrap();
+            assert!(loaded.assets.iter().all(|asset| !asset.verified));
+            assert!(loaded.assets.contains(AssetCode::native()));
+            assert!(loaded.assets.contains(asset1.code));
+            assert!(!loaded.assets.contains(asset2.code));
+            assert_eq!(loaded.assets.len(), 2);
+        }
+
+        // Now import `asset2`, updating the existing verified asset with persistence and mint info.
+        wallets[0]
+            .0
+            .import_asset(AssetInfo::new(asset2.clone(), mint_info2.clone()))
+            .await
+            .unwrap();
+        assert_eq!(
+            wallets[0].0.asset(asset2.code).await.unwrap(),
+            AssetInfo {
+                definition: asset2.clone(),
+                mint_info: Some(mint_info2),
+                verified: true,
+                temporary: false,
+            }
+        );
+
+        // Check that `asset2` is now persisted, but still no assets in storage are verified.
+        {
+            let storage = &ledger.lock().await.storage[0];
+            let loaded = storage.lock().await.load().await.unwrap();
+            assert!(loaded.assets.iter().all(|asset| !asset.verified));
+            assert!(loaded.assets.contains(AssetCode::native()));
+            assert!(loaded.assets.contains(asset1.code));
+            assert!(loaded.assets.contains(asset2.code));
+            assert_eq!(loaded.assets.len(), 3);
+        }
+
+        // Finally, check that by loading the persisted, unverified information, and combining it
+        // with the verified information, we get back the current in-memory information (which was
+        // generated in a different order).
+        let loaded = {
+            let storage = &ledger.lock().await.storage[0];
+            let mut assets = storage.lock().await.load().await.unwrap().assets;
+            for asset in imported {
+                assets.insert(asset);
+            }
+            assets
+        };
+        assert_eq!(loaded, wallets[0].0.lock().await.state.assets);
     }
 }

--- a/src/testing/tests.rs
+++ b/src/testing/tests.rs
@@ -1795,11 +1795,22 @@ pub mod generic_wallet_tests {
         let loaded = {
             let storage = &ledger.lock().await.storage[0];
             let mut assets = storage.lock().await.load().await.unwrap().assets;
-            for asset in imported {
-                assets.insert(asset);
+            for asset in &imported {
+                assets.insert(asset.clone());
             }
             assets
         };
         assert_eq!(loaded, wallets[0].0.lock().await.state.assets);
+
+        // Check that the verified assets are marked verified once again.
+        for asset in loaded {
+            assert_eq!(
+                asset.verified,
+                imported
+                    .iter()
+                    .find(|verified| verified.definition == asset.definition)
+                    .is_some()
+            );
+        }
     }
 }


### PR DESCRIPTION
Extends Seahorse with the ability to
* create and sign files containing lists of assets
* verify and import these files in order to mark certain assets "verified"

The plan is to apply this to CAPE by
* generating a signing key pair specific to the CAPE wallet
* using the signing key (which should be kept a secret of Espresso Systems)
  to sign a set of official CAPE assets
* distribute the signed CAPE asset library with the CAPE wallet
* adding code around CapeWallet creation to load and verify the CAPE asset library

Closes #30 
See EspressoSystems/cape-ui#37