### PR TITLE
Clean up handling of transaction outputs.

### DIFF
--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -551,7 +551,10 @@ mod tests {
         repeat_with(|| random_ro(rng, key_pair)).take(3).collect()
     }
 
-    fn random_memos(rng: &mut ChaChaRng, key_pair: &UserKeyPair) -> (Vec<ReceiverMemo>, Signature) {
+    fn random_memos(
+        rng: &mut ChaChaRng,
+        key_pair: &UserKeyPair,
+    ) -> (Vec<Option<ReceiverMemo>>, Signature) {
         let memos = repeat_with(|| {
             let ro = random_ro(rng, key_pair);
             ReceiverMemo::from_ro(rng, &ro, &[]).unwrap()
@@ -559,7 +562,7 @@ mod tests {
         .take(3)
         .collect::<Vec<_>>();
         let sig = sign_receiver_memos(&KeyPair::generate(rng), &memos).unwrap();
-        (memos, sig)
+        (memos.into_iter().map(|memo| Some(memo)).collect(), sig)
     }
 
     fn random_txn_hash(rng: &mut ChaChaRng) -> Commitment<cap::Transaction> {

--- a/src/testing/mocks.rs
+++ b/src/testing/mocks.rs
@@ -411,7 +411,12 @@ impl<'a> WalletBackend<'a, cap::Ledger> for MockBackend<'a> {
             self.ledger
                 .lock()
                 .await
-                .post_memos(block_id, txn_id, txn.info.memos, txn.info.sig)
+                .post_memos(
+                    block_id,
+                    txn_id,
+                    txn.info.memos.into_iter().flatten().collect(),
+                    txn.info.sig,
+                )
                 .unwrap();
         }
     }

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -20,7 +20,7 @@ use async_std::sync::{Arc, Mutex};
 use futures::channel::mpsc;
 use jf_cap::structs::NoteType;
 use jf_cap::utils::compute_universal_param_size;
-use jf_cap::{proof::UniversalParam, MerkleTree, TransactionVerifyingKey};
+use jf_cap::{proof::UniversalParam, MerkleTree, Signature, TransactionVerifyingKey};
 use key_set::{KeySet, OrderByOutputs, ProverKeySet, VerifierKeySet};
 use lazy_static::lazy_static;
 use rand_chacha::rand_core::RngCore;


### PR DESCRIPTION
* Built-in feature for burning outputs (in the general sense, not
  the specific CAPE sense). Will be needed for #67.
* Fixes #13

For a while I thought I needed this for the CAPE wallet integration. Turns out it's not needed for that, but I think it's an improvement and we will want it eventually anyways.