### PR TITLE
Make freezing independent from get_public_key and modify backend records type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3218,6 +3218,7 @@ dependencies = [
  "image",
  "itertools",
  "jf-cap",
+ "jf-primitives",
  "jf-utils",
  "key-set",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ commit = { git = "https://github.com/EspressoSystems/commit.git", tag = "0.1.0" 
 key-set = { git = "https://github.com/EspressoSystems/key-set.git" }
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git" }
 jf-cap = { features=["std"], git = "https://github.com/EspressoSystems/cap.git" }
+jf-primitives = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git" }
 jf-utils = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git" }
 arbitrary-wrappers = { git = "https://github.com/EspressoSystems/arbitrary-wrappers.git" }
 net = { git = "https://github.com/EspressoSystems/net.git" }

--- a/src/testing/mocks.rs
+++ b/src/testing/mocks.rs
@@ -106,7 +106,7 @@ pub struct MockNetwork<'a> {
     records: MerkleTree,
     committed_blocks: Vec<(cap::Block, Vec<Vec<u64>>)>,
     proving_keys: Arc<ProverKeySet<'a, key_set::OrderByOutputs>>,
-    pub address_map: HashMap<UserAddress, UserPubKey>,
+    address_map: HashMap<UserAddress, UserPubKey>,
     events: MockEventSource<cap::Ledger>,
 }
 

--- a/src/testing/mocks.rs
+++ b/src/testing/mocks.rs
@@ -106,7 +106,7 @@ pub struct MockNetwork<'a> {
     records: MerkleTree,
     committed_blocks: Vec<(cap::Block, Vec<Vec<u64>>)>,
     proving_keys: Arc<ProverKeySet<'a, key_set::OrderByOutputs>>,
-    address_map: HashMap<UserAddress, UserPubKey>,
+    pub address_map: HashMap<UserAddress, UserPubKey>,
     events: MockEventSource<cap::Ledger>,
 }
 

--- a/src/testing/tests.rs
+++ b/src/testing/tests.rs
@@ -31,7 +31,7 @@ impl<L: Ledger> PartialEq<Self> for TxnHistoryWithTimeTolerantEq<L> {
 #[generic_tests]
 pub mod generic_wallet_tests {
     use super::*;
-    use crate::asset_library::Icon;
+    use crate::{asset_library::Icon, testing::mocks::MockSystem};
     use async_std::task::block_on;
     use jf_cap::KeyPair;
     use proptest::{collection::vec, strategy::Strategy, test_runner, test_runner::TestRunner};
@@ -883,6 +883,139 @@ pub mod generic_wallet_tests {
         assert_eq!(actual_history, expected_history);
 
         Ok(())
+    }
+
+    #[async_std::test]
+    pub async fn test_wallet_freeze_unregistered<'a, T: SystemUnderTest<'a>>() -> std::io::Result<()>
+    {
+        let mut t = MockSystem::default();
+        let mut now = Instant::now();
+
+        // Wallets[0], [1] and [2] will act as the sender, receiver and freezer, respectively.
+        let (ledger, mut wallets) = t
+            .create_test_network(&[(3, 3)], vec![2, 0, 6], &mut now)
+            .await;
+
+        // Set `block_size` to `1` so we don't have to explicitly flush the ledger after each
+        // transaction submission.
+        ledger.lock().await.set_block_size(1).unwrap();
+
+        let asset = {
+            let mut rng = ChaChaRng::from_seed([42u8; 32]);
+            let audit_key = AuditorKeyPair::generate(&mut rng);
+            let freeze_key = FreezerKeyPair::generate(&mut rng);
+            let policy = AssetPolicy::default()
+                .set_auditor_pub_key(audit_key.pub_key())
+                .set_freezer_pub_key(freeze_key.pub_key())
+                .reveal_record_opening()
+                .unwrap();
+            wallets[2]
+                .0
+                .add_audit_key(audit_key, "audit_key".into())
+                .await
+                .unwrap();
+            wallets[2]
+                .0
+                .add_freeze_key(freeze_key, "freeze_key".into())
+                .await
+                .unwrap();
+            let asset = wallets[2]
+                .0
+                .define_asset("test".into(), "test asset".as_bytes(), policy)
+                .await
+                .unwrap();
+
+            // The first address of wallets[0] gets 1 coin to transfer to wallets[1].
+            let src = wallets[2].1[0].clone();
+            let dst = wallets[0].1[0].clone();
+            wallets[2]
+                .0
+                .mint(&src, 1, &asset.code, 1, dst)
+                .await
+                .unwrap();
+            t.sync(&ledger, wallets.as_slice()).await;
+
+            asset
+        };
+
+        // Check the balance after minting.
+        assert_eq!(
+            wallets[0]
+                .0
+                .balance_breakdown(&wallets[0].1[0], &asset.code)
+                .await,
+            1
+        );
+        assert_eq!(
+            wallets[0]
+                .0
+                .frozen_balance_breakdown(&wallets[0].1[0], &asset.code)
+                .await,
+            0
+        );
+
+        // Unregister wallets[0]'s first address by removing it from the address map.
+        ledger
+            .lock()
+            .await
+            .network()
+            .address_map
+            .remove(&wallets[0].1[0]);
+
+        // Freeze wallets[0]'s record.
+        println!(
+            "generating a freeze transaction: {}s",
+            now.elapsed().as_secs_f32()
+        );
+        now = Instant::now();
+        let src = wallets[2].1[0].clone();
+        let dst = wallets[0].1[0].clone();
+        ledger.lock().await.hold_next_transaction();
+        wallets[2]
+            .0
+            .freeze(&src, 1, &asset.code, 1, dst.clone())
+            .await
+            .unwrap();
+
+        // Check the balance after freezing.
+        ledger.lock().await.release_held_transaction();
+        t.sync(&ledger, wallets.as_slice()).await;
+        assert_eq!(
+            wallets[0]
+                .0
+                .balance_breakdown(&wallets[0].1[0], &asset.code)
+                .await,
+            0
+        );
+        assert_eq!(
+            wallets[0]
+                .0
+                .frozen_balance_breakdown(&wallets[0].1[0], &asset.code)
+                .await,
+            1
+        );
+
+        // Check that trying to transfer fails due to frozen balance.
+        println!("generating a transfer: {}s", now.elapsed().as_secs_f32());
+        now = Instant::now();
+        let src = wallets[0].1[0].clone();
+        let dst = wallets[1].1[0].clone();
+        match wallets[0]
+            .0
+            .transfer(Some(&src), &asset.code, &[(dst, 1)], 1)
+            .await
+        {
+            Err(WalletError::TransactionError {
+                source: TransactionError::InsufficientBalance { .. },
+            }) => {
+                println!(
+                    "transfer correctly failed due to frozen balance: {}s",
+                    now.elapsed().as_secs_f32()
+                );
+                Ok(())
+            }
+            ret => panic!("expected InsufficientBalance, got {:?}", ret.map(|_| ())),
+        }
     }
 
     /*

--- a/src/testing/tests.rs
+++ b/src/testing/tests.rs
@@ -6,6 +6,7 @@
 // You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
+use crate::testing::mocks::MockSystem;
 use chrono::Duration;
 use espresso_macros::generic_tests;
 
@@ -28,10 +29,142 @@ impl<L: Ledger> PartialEq<Self> for TxnHistoryWithTimeTolerantEq<L> {
     }
 }
 
+#[async_std::test]
+pub async fn test_wallet_freeze_unregistered() -> std::io::Result<()> {
+    let mut t = MockSystem::default();
+    let mut now = Instant::now();
+
+    // Wallets[0], [1] and [2] will act as the sender, receiver and freezer, respectively.
+    let (ledger, mut wallets) = t
+        .create_test_network(&[(3, 3)], vec![2, 0, 6], &mut now)
+        .await;
+
+    // Set `block_size` to `1` so we don't have to explicitly flush the ledger after each
+    // transaction submission.
+    ledger.lock().await.set_block_size(1).unwrap();
+
+    let asset = {
+        let mut rng = ChaChaRng::from_seed([42u8; 32]);
+        let audit_key = AuditorKeyPair::generate(&mut rng);
+        let freeze_key = FreezerKeyPair::generate(&mut rng);
+        let policy = AssetPolicy::default()
+            .set_auditor_pub_key(audit_key.pub_key())
+            .set_freezer_pub_key(freeze_key.pub_key())
+            .reveal_record_opening()
+            .unwrap();
+        wallets[2]
+            .0
+            .add_audit_key(audit_key, "audit_key".into())
+            .await
+            .unwrap();
+        wallets[2]
+            .0
+            .add_freeze_key(freeze_key, "freeze_key".into())
+            .await
+            .unwrap();
+        let asset = wallets[2]
+            .0
+            .define_asset("test".into(), "test asset".as_bytes(), policy)
+            .await
+            .unwrap();
+
+        // The first address of wallets[0] gets 1 coin to transfer to wallets[1].
+        let src = wallets[2].1[0].clone();
+        let dst = wallets[0].1[0].clone();
+        wallets[2]
+            .0
+            .mint(&src, 1, &asset.code, 1, dst)
+            .await
+            .unwrap();
+        t.sync(&ledger, wallets.as_slice()).await;
+
+        asset
+    };
+
+    // Check the balance after minting.
+    assert_eq!(
+        wallets[0]
+            .0
+            .balance_breakdown(&wallets[0].1[0], &asset.code)
+            .await,
+        1
+    );
+    assert_eq!(
+        wallets[0]
+            .0
+            .frozen_balance_breakdown(&wallets[0].1[0], &asset.code)
+            .await,
+        0
+    );
+
+    // Unregister wallets[0]'s first address by removing it from the address map.
+    ledger
+        .lock()
+        .await
+        .network()
+        .address_map
+        .remove(&wallets[0].1[0]);
+
+    // Freeze wallets[0]'s record.
+    println!(
+        "generating a freeze transaction: {}s",
+        now.elapsed().as_secs_f32()
+    );
+    now = Instant::now();
+    let src = wallets[2].1[0].clone();
+    let dst = wallets[0].1[0].clone();
+    ledger.lock().await.hold_next_transaction();
+    wallets[2]
+        .0
+        .freeze(&src, 1, &asset.code, 1, dst.clone())
+        .await
+        .unwrap();
+
+    // Check the balance after freezing.
+    ledger.lock().await.release_held_transaction();
+    t.sync(&ledger, wallets.as_slice()).await;
+    assert_eq!(
+        wallets[0]
+            .0
+            .balance_breakdown(&wallets[0].1[0], &asset.code)
+            .await,
+        0
+    );
+    assert_eq!(
+        wallets[0]
+            .0
+            .frozen_balance_breakdown(&wallets[0].1[0], &asset.code)
+            .await,
+        1
+    );
+
+    // Check that trying to transfer fails due to frozen balance.
+    println!("generating a transfer: {}s", now.elapsed().as_secs_f32());
+    now = Instant::now();
+    let src = wallets[0].1[0].clone();
+    let dst = wallets[1].1[0].clone();
+    match wallets[0]
+        .0
+        .transfer(Some(&src), &asset.code, &[(dst, 1)], 1)
+        .await
+    {
+        Err(WalletError::TransactionError {
+            source: TransactionError::InsufficientBalance { .. },
+        }) => {
+            println!(
+                "transfer correctly failed due to frozen balance: {}s",
+                now.elapsed().as_secs_f32()
+            );
+            Ok(())
+        }
+        ret => panic!("expected InsufficientBalance, got {:?}", ret.map(|_| ())),
+    }
+}
+
 #[generic_tests]
 pub mod generic_wallet_tests {
     use super::*;
-    use crate::{asset_library::Icon, testing::mocks::MockSystem};
+    use crate::asset_library::Icon;
     use async_std::task::block_on;
     use jf_cap::KeyPair;
     use proptest::{collection::vec, strategy::Strategy, test_runner, test_runner::TestRunner};
@@ -883,139 +1016,6 @@ pub mod generic_wallet_tests {
         assert_eq!(actual_history, expected_history);
 
         Ok(())
-    }
-
-    #[async_std::test]
-    pub async fn test_wallet_freeze_unregistered<'a, T: SystemUnderTest<'a>>() -> std::io::Result<()>
-    {
-        let mut t = MockSystem::default();
-        let mut now = Instant::now();
-
-        // Wallets[0], [1] and [2] will act as the sender, receiver and freezer, respectively.
-        let (ledger, mut wallets) = t
-            .create_test_network(&[(3, 3)], vec![2, 0, 6], &mut now)
-            .await;
-
-        // Set `block_size` to `1` so we don't have to explicitly flush the ledger after each
-        // transaction submission.
-        ledger.lock().await.set_block_size(1).unwrap();
-
-        let asset = {
-            let mut rng = ChaChaRng::from_seed([42u8; 32]);
-            let audit_key = AuditorKeyPair::generate(&mut rng);
-            let freeze_key = FreezerKeyPair::generate(&mut rng);
-            let policy = AssetPolicy::default()
-                .set_auditor_pub_key(audit_key.pub_key())
-                .set_freezer_pub_key(freeze_key.pub_key())
-                .reveal_record_opening()
-                .unwrap();
-            wallets[2]
-                .0
-                .add_audit_key(audit_key, "audit_key".into())
-                .await
-                .unwrap();
-            wallets[2]
-                .0
-                .add_freeze_key(freeze_key, "freeze_key".into())
-                .await
-                .unwrap();
-            let asset = wallets[2]
-                .0
-                .define_asset("test".into(), "test asset".as_bytes(), policy)
-                .await
-                .unwrap();
-
-            // The first address of wallets[0] gets 1 coin to transfer to wallets[1].
-            let src = wallets[2].1[0].clone();
-            let dst = wallets[0].1[0].clone();
-            wallets[2]
-                .0
-                .mint(&src, 1, &asset.code, 1, dst)
-                .await
-                .unwrap();
-            t.sync(&ledger, wallets.as_slice()).await;
-
-            asset
-        };
-
-        // Check the balance after minting.
-        assert_eq!(
-            wallets[0]
-                .0
-                .balance_breakdown(&wallets[0].1[0], &asset.code)
-                .await,
-            1
-        );
-        assert_eq!(
-            wallets[0]
-                .0
-                .frozen_balance_breakdown(&wallets[0].1[0], &asset.code)
-                .await,
-            0
-        );
-
-        // Unregister wallets[0]'s first address by removing it from the address map.
-        ledger
-            .lock()
-            .await
-            .network()
-            .address_map
-            .remove(&wallets[0].1[0]);
-
-        // Freeze wallets[0]'s record.
-        println!(
-            "generating a freeze transaction: {}s",
-            now.elapsed().as_secs_f32()
-        );
-        now = Instant::now();
-        let src = wallets[2].1[0].clone();
-        let dst = wallets[0].1[0].clone();
-        ledger.lock().await.hold_next_transaction();
-        wallets[2]
-            .0
-            .freeze(&src, 1, &asset.code, 1, dst.clone())
-            .await
-            .unwrap();
-
-        // Check the balance after freezing.
-        ledger.lock().await.release_held_transaction();
-        t.sync(&ledger, wallets.as_slice()).await;
-        assert_eq!(
-            wallets[0]
-                .0
-                .balance_breakdown(&wallets[0].1[0], &asset.code)
-                .await,
-            0
-        );
-        assert_eq!(
-            wallets[0]
-                .0
-                .frozen_balance_breakdown(&wallets[0].1[0], &asset.code)
-                .await,
-            1
-        );
-
-        // Check that trying to transfer fails due to frozen balance.
-        println!("generating a transfer: {}s", now.elapsed().as_secs_f32());
-        now = Instant::now();
-        let src = wallets[0].1[0].clone();
-        let dst = wallets[1].1[0].clone();
-        match wallets[0]
-            .0
-            .transfer(Some(&src), &asset.code, &[(dst, 1)], 1)
-            .await
-        {
-            Err(WalletError::TransactionError {
-                source: TransactionError::InsufficientBalance { .. },
-            }) => {
-                println!(
-                    "transfer correctly failed due to frozen balance: {}s",
-                    now.elapsed().as_secs_f32()
-                );
-                Ok(())
-            }
-            ret => panic!("expected InsufficientBalance, got {:?}", ret.map(|_| ())),
-        }
     }
 
     /*


### PR DESCRIPTION
- Uses `UserAddress` rather than `UserPubKey` for freezing, to make freezing independent from `get_public_key`, i.e., user registeration.
- Modifies asset records type in the backend to use `UserAddress` as the lookup key, so that we don't need the encryption key to construct a `UserPubKey`.

Closes https://github.com/EspressoSystems/seahorse/issues/37.