### PR TITLE
Move key scans into account data structures.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3211,6 +3211,7 @@ dependencies = [
  "chacha20",
  "chrono",
  "commit",
+ "derivative",
  "espresso-macros 0.1.0 (git+https://github.com/EspressoSystems/espresso-macros.git)",
  "futures",
  "generic-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ bincode = "1.3.3"
 bip0039 = "0.10"
 chacha20 = "0.8.1"
 chrono = "0.4.19"
+derivative = "2.2"
 futures = "0.3.16"
 generic-array = { version = "0.14.4", features = ["serde"] }
 hmac = "0.11.0"

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -1,73 +1,122 @@
 /// Keys and associated data.
-use crate::{txn_builder::RecordInfo, AssetInfo};
+use crate::{
+    events::{EventIndex, EventSource, LedgerEvent},
+    key_scan::{BackgroundKeyScan, ScanOutputs},
+    txn_builder::RecordInfo,
+    AssetInfo,
+};
 use arbitrary::{Arbitrary, Unstructured};
 use arbitrary_wrappers::{ArbitraryAuditorKeyPair, ArbitraryFreezerKeyPair, ArbitraryUserKeyPair};
+use derivative::Derivative;
 use espresso_macros::ser_test;
-use jf_cap::keys::{
-    AuditorKeyPair, AuditorPubKey, FreezerKeyPair, FreezerPubKey, UserAddress, UserKeyPair,
+use jf_cap::{
+    keys::{
+        AuditorKeyPair, AuditorPubKey, FreezerKeyPair, FreezerPubKey, UserAddress, UserKeyPair,
+    },
+    MerkleCommitment,
 };
-use serde::{Deserialize, Serialize};
+use reef::{Ledger, TransactionHash};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::fmt::Debug;
 
 /// The persistent representation of an account.
 #[ser_test(
     arbitrary,
     ark(false),
-    types(AuditorKeyPair),
-    types(FreezerKeyPair),
-    types(UserKeyPair)
+    types(reef::cap::Ledger, AuditorKeyPair),
+    types(reef::cap::Ledger, FreezerKeyPair),
+    types(reef::cap::Ledger, UserKeyPair)
 )]
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Account<Key> {
+#[derive(Derivative, Serialize, Deserialize)]
+#[derivative(
+    Clone(bound = "L: Ledger, Key: Clone"),
+    Debug(bound = "L: Ledger, Key: Debug")
+)]
+#[serde(bound = "L: Ledger, Key: Serialize + DeserializeOwned")]
+pub struct Account<L: Ledger, Key> {
     pub(crate) key: Key,
     pub(crate) description: String,
     pub(crate) used: bool,
+    pub(crate) scan: Option<BackgroundKeyScan<L>>,
 }
 
-impl<Key> Account<Key> {
+impl<L: Ledger, Key> Account<L, Key> {
     pub fn new(key: Key, description: String) -> Self {
         Self {
             key,
             description,
             used: false,
+            scan: None,
+        }
+    }
+
+    pub(crate) async fn update_scan(
+        &mut self,
+        event: LedgerEvent<L>,
+        source: EventSource,
+        records_commitment: MerkleCommitment,
+    ) -> Option<(UserKeyPair, ScanOutputs<L>)> {
+        let mut scan = self.scan.take().unwrap();
+        scan.handle_event(event, source);
+        // Check if the scan is complete.
+        match scan.finalize(records_commitment) {
+            Ok(result) => Some(result),
+            Err(scan) => {
+                self.scan = Some(scan);
+                None
+            }
         }
     }
 }
 
-impl<Key: KeyPair> PartialEq<Self> for Account<Key> {
+impl<L: Ledger, Key: KeyPair> PartialEq<Self> for Account<L, Key> {
     fn eq(&self, other: &Self) -> bool {
         // We assume that the private keys are equal if the public keys are.
         self.key.pub_key() == other.key.pub_key()
             && self.description == other.description
             && self.used == other.used
+            && self.scan == other.scan
     }
 }
 
-impl<'a> Arbitrary<'a> for Account<AuditorKeyPair> {
+impl<'a, L: Ledger> Arbitrary<'a> for Account<L, AuditorKeyPair>
+where
+    TransactionHash<L>: Arbitrary<'a>,
+{
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self {
             key: u.arbitrary::<ArbitraryAuditorKeyPair>()?.into(),
             description: u.arbitrary()?,
             used: u.arbitrary()?,
+            scan: u.arbitrary()?,
         })
     }
 }
 
-impl<'a> Arbitrary<'a> for Account<FreezerKeyPair> {
+impl<'a, L: Ledger> Arbitrary<'a> for Account<L, FreezerKeyPair>
+where
+    TransactionHash<L>: Arbitrary<'a>,
+{
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self {
             key: u.arbitrary::<ArbitraryFreezerKeyPair>()?.into(),
             description: u.arbitrary()?,
             used: u.arbitrary()?,
+            scan: u.arbitrary()?,
         })
     }
 }
 
-impl<'a> Arbitrary<'a> for Account<UserKeyPair> {
+impl<'a, L: Ledger> Arbitrary<'a> for Account<L, UserKeyPair>
+where
+    TransactionHash<L>: Arbitrary<'a>,
+{
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self {
             key: u.arbitrary::<ArbitraryUserKeyPair>()?.into(),
             description: u.arbitrary()?,
             used: u.arbitrary()?,
+            scan: u.arbitrary()?,
         })
     }
 }
@@ -81,10 +130,22 @@ pub struct AccountInfo<Key: KeyPair> {
     pub assets: Vec<AssetInfo>,
     pub records: Vec<RecordInfo>,
     pub balance: u64,
+    /// The status of a ledger scan for this account's key.
+    ///
+    /// If a ledger scan using this account's key is in progress, `scan_status` contains the index
+    /// of the next event to be scanned and the index of the last event in the scan's range of
+    /// interest, in that order. Note that the former may be greater than the latter, since the scan
+    /// will not complete until it has caught with the main event loop, which may have advanced past
+    /// the end of the range of interest.
+    pub scan_status: Option<(EventIndex, EventIndex)>,
 }
 
 impl<Key: KeyPair> AccountInfo<Key> {
-    pub fn new(account: Account<Key>, assets: Vec<AssetInfo>, records: Vec<RecordInfo>) -> Self {
+    pub fn new<L: Ledger>(
+        account: Account<L, Key>,
+        assets: Vec<AssetInfo>,
+        records: Vec<RecordInfo>,
+    ) -> Self {
         Self {
             address: account.key.pub_key(),
             description: account.description,
@@ -92,6 +153,7 @@ impl<Key: KeyPair> AccountInfo<Key> {
             balance: records.iter().map(|rec| rec.ro.amount).sum(),
             assets,
             records,
+            scan_status: account.scan.map(|scan| (scan.status())),
         }
     }
 }
@@ -104,6 +166,7 @@ impl<Key: KeyPair> PartialEq<Self> for AccountInfo<Key> {
             && self.assets == other.assets
             && self.records == other.records
             && self.balance == other.balance
+            && self.scan_status == other.scan_status
     }
 }
 

--- a/src/key_scan.rs
+++ b/src/key_scan.rs
@@ -191,6 +191,16 @@ impl<L: Ledger> BackgroundKeyScan<L> {
         self.next_event
     }
 
+    /// The status of a ledger scan.
+    ///
+    /// Returns (`next_event`, `to_event`) where `next_event` is the index of the next event to be
+    /// scanned and `to_event` is the index of the last event in the scan's range of interest. Note
+    /// that the `next_event` may be greater than `to_event`, since the scan will not complete until
+    /// it has caught with the main event loop, which may have advanced past `to_event`.
+    pub fn status(&self) -> (EventIndex, EventIndex) {
+        (self.next_event, self.to_event)
+    }
+
     pub fn handle_event(&mut self, event: LedgerEvent<L>, source: EventSource) {
         if self.from_event.index(source) <= self.next_event.index(source)
             && self.next_event.index(source) < self.to_event.index(source)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,9 +253,6 @@ pub struct WalletState<'a, L: Ledger> {
     ////////////////////////////////////////////////////////////////////////////////////////////////
     // Monotonic data
     //
-    // Note: the sets of keys should be moved to the txn state
-    // (https://github.com/spectrum-eco/spectrum/issues/6).
-    //
     /// Asset library.
     ///
     /// This contains information about all of the asset types imported or discovered by this

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,10 +237,18 @@ pub struct WalletState<'a, L: Ledger> {
     ///
     /// Everything we need to know about the state of the ledger in order to build transactions.
     pub txn_state: TransactionState<L>,
-    /// Background scans triggered by the addition of new keys.
-    pub key_scans: HashMap<UserAddress, BackgroundKeyScan<L>>,
     /// HD key generation state.
     pub key_state: KeyStreamState,
+    /// Viewing keys.
+    pub viewing_accounts: HashMap<AuditorPubKey, Account<L, AuditorKeyPair>>,
+    /// Freezing keys.
+    pub freezing_accounts: HashMap<FreezerPubKey, Account<L, FreezerKeyPair>>,
+    /// Sending keys, for spending owned records and receiving new records.
+    ///
+    /// Each public key in this set also includes a [UserAddress], which can be used to sign
+    /// outgoing transactions, as well as an encryption public key used by other users to encrypt
+    /// owner memos when sending records to this wallet.
+    pub sending_accounts: HashMap<UserAddress, Account<L, UserKeyPair>>,
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
     // Monotonic data
@@ -254,16 +262,6 @@ pub struct WalletState<'a, L: Ledger> {
     /// wallet. For assets created by this wallets, in includes information needed to mint the
     /// assets, including the asset description and the private asset code seed.
     pub assets: AssetLibrary,
-    /// Viewing keys.
-    pub viewing_accounts: HashMap<AuditorPubKey, Account<AuditorKeyPair>>,
-    /// Freezing keys.
-    pub freezing_accounts: HashMap<FreezerPubKey, Account<FreezerKeyPair>>,
-    /// Sending keys, for spending owned records and receiving new records.
-    ///
-    /// Each public key in this set also includes a [UserAddress], which can be used to sign
-    /// outgoing transactions, as well as an encryption public key used by other users to encrypt
-    /// owner memos when sending records to this wallet.
-    pub sending_accounts: HashMap<UserAddress, Account<UserKeyPair>>,
 }
 
 /// The interface required by the wallet from the persistence layer.
@@ -1399,36 +1397,26 @@ impl<'a, L: 'static + Ledger> WalletState<'a, L> {
             }
         };
 
-        let events = if let Some(scan_from) = scan_from {
+        let (scan, events) = if let Some(scan_from) = scan_from {
             // Get the stream of events for the background scan worker task to process.
             let (frontier, next_event) = session.backend.get_initial_scan_state(scan_from).await?;
             let events = session.backend.subscribe(next_event, None).await;
 
-            // Register a background scan of the ledger to import records belonging to this key.
-            //
-            // Note that there cannot already be a key scan registered for this key (hence the
-            // assert) since we have already checked that we don't yet have this key. This is
-            // important for the rollback logic below, in the case where we fail to persist the
-            // update.
-            assert!(self
-                .key_scans
-                .insert(
-                    user_key.address(),
-                    BackgroundKeyScan::new(
-                        user_key.clone(),
-                        next_event,
-                        scan_from,
-                        self.txn_state.now,
-                        frontier
-                    ),
-                )
-                .is_none());
-            Some(events)
+            // Create a background scan of the ledger to import records belonging to this key.
+            let scan = BackgroundKeyScan::new(
+                user_key.clone(),
+                next_event,
+                scan_from,
+                self.txn_state.now,
+                frontier,
+            );
+            (Some(scan), Some(events))
         } else {
-            None
+            (None, None)
         };
 
-        let account = Account::new(user_key.clone(), description);
+        let mut account = Account::new(user_key.clone(), description);
+        account.scan = scan;
 
         // Add the new account to our set of accounts and update our persistent data structures and
         // remote services.
@@ -1446,7 +1434,6 @@ impl<'a, L: 'static + Ledger> WalletState<'a, L> {
         {
             // If anything went wrong, no storage transaction was committed. Revert our changes to
             // in-memory data structures before returning the error.
-            self.key_scans.remove(&user_key.address());
             if let Some(old_key_state) = revert_key_state {
                 self.key_state.user = old_key_state;
             }
@@ -1773,11 +1760,13 @@ impl<'a, L: 'static + Ledger, Backend: 'a + WalletBackend<'a, L> + Send + Sync>
         let mut state = backend.load().await?;
         let mut events = backend.subscribe(state.txn_state.now, None).await;
         let mut key_scans = vec![];
-        for scan in state.key_scans.values() {
-            key_scans.push((
-                scan.address(),
-                backend.subscribe(scan.next_event(), None).await,
-            ));
+        for account in state.viewing_accounts.values() {
+            if let Some(scan) = &account.scan {
+                key_scans.push((
+                    scan.address(),
+                    backend.subscribe(scan.next_event(), None).await,
+                ));
+            }
         }
         let key_tree = backend.key_stream();
         let mut session = WalletSession {
@@ -2704,43 +2693,42 @@ impl<'a, L: 'static + Ledger, Backend: 'a + WalletBackend<'a, L> + Send + Sync>
                         pending_key_scans,
                         ..
                     } = &mut *mutex.lock().await;
-                    let mut scan = state.key_scans.remove(&address).unwrap();
-                    scan.handle_event(event, source);
-                    // Check if the scan is complete.
-                    let finished = match scan.finalize(state.txn_state.record_mt.commitment()) {
-                        Ok((key, ScanOutputs { records, history })) => {
-                            if let Err(err) = state.add_records(session, &key, records).await {
-                                println!("Error saving records from key scan {}: {}", address, err);
-                            }
-                            if let Err(err) = session
-                                .backend
-                                .store(|mut t| async {
-                                    for h in history {
-                                        t.store_transaction(h).await?;
-                                    }
-                                    Ok(t)
-                                })
-                                .await
-                            {
-                                println!(
-                                    "Error saving tranaction history from key scan {}: {}",
-                                    address, err
-                                );
-                            }
-
-                            // Signal anyone waiting for a notification that this scan finished.
-                            for sender in pending_key_scans.remove(&address).into_iter().flatten() {
-                                // Ignore errors, it just means the receiving end of the channel has
-                                // been dropped.
-                                sender.send(()).ok();
-                            }
-
-                            true
+                    let finished = if let Some((key, ScanOutputs { records, history })) = state
+                        .sending_accounts
+                        .get_mut(&address)
+                        .unwrap()
+                        .update_scan(event, source, state.txn_state.record_mt.commitment())
+                        .await
+                    {
+                        if let Err(err) = state.add_records(session, &key, records).await {
+                            println!("Error saving records from key scan {}: {}", address, err);
                         }
-                        Err(scan) => {
-                            state.key_scans.insert(address.clone(), scan);
-                            false
+                        if let Err(err) = session
+                            .backend
+                            .store(|mut t| async {
+                                for h in history {
+                                    t.store_transaction(h).await?;
+                                }
+                                Ok(t)
+                            })
+                            .await
+                        {
+                            println!(
+                                "Error saving tranaction history from key scan {}: {}",
+                                address, err
+                            );
                         }
+
+                        // Signal anyone waiting for a notification that this scan finished.
+                        for sender in pending_key_scans.remove(&address).into_iter().flatten() {
+                            // Ignore errors, it just means the receiving end of the channel has
+                            // been dropped.
+                            sender.send(()).ok();
+                        }
+
+                        true
+                    } else {
+                        false
                     };
 
                     session

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -13,8 +13,7 @@ use crate::{
     hd::KeyTree,
     loader::WalletLoader,
     txn_builder::TransactionState,
-    BackgroundKeyScan, KeyStreamState, TransactionHistoryEntry, WalletError, WalletState,
-    WalletStorage,
+    KeyStreamState, TransactionHistoryEntry, WalletError, WalletState, WalletStorage,
 };
 use arbitrary::{Arbitrary, Unstructured};
 use async_std::sync::Arc;
@@ -78,17 +77,15 @@ mod serde_ark_unchecked {
 #[serde(bound = "")]
 struct WalletSnapshot<L: Ledger> {
     txn_state: TransactionState<L>,
-    key_scans: Vec<BackgroundKeyScan<L>>,
     key_state: KeyStreamState,
-    viewing_accounts: Vec<Account<AuditorKeyPair>>,
-    freezing_accounts: Vec<Account<FreezerKeyPair>>,
-    sending_accounts: Vec<Account<UserKeyPair>>,
+    viewing_accounts: Vec<Account<L, AuditorKeyPair>>,
+    freezing_accounts: Vec<Account<L, FreezerKeyPair>>,
+    sending_accounts: Vec<Account<L, UserKeyPair>>,
 }
 
 impl<L: Ledger> PartialEq<Self> for WalletSnapshot<L> {
     fn eq(&self, other: &Self) -> bool {
         self.txn_state == other.txn_state
-            && self.key_scans == other.key_scans
             && self.key_state == other.key_state
             && self.viewing_accounts == other.viewing_accounts
             && self.freezing_accounts == other.freezing_accounts
@@ -100,7 +97,6 @@ impl<'a, L: Ledger> From<&WalletState<'a, L>> for WalletSnapshot<L> {
     fn from(w: &WalletState<'a, L>) -> Self {
         Self {
             txn_state: w.txn_state.clone(),
-            key_scans: w.key_scans.values().cloned().collect(),
             key_state: w.key_state.clone(),
             viewing_accounts: w.viewing_accounts.values().cloned().collect(),
             freezing_accounts: w.freezing_accounts.values().cloned().collect(),
@@ -117,7 +113,6 @@ where
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self {
             txn_state: u.arbitrary()?,
-            key_scans: u.arbitrary()?,
             key_state: u.arbitrary()?,
             viewing_accounts: u.arbitrary()?,
             freezing_accounts: u.arbitrary()?,
@@ -356,11 +351,6 @@ impl<'a, L: Ledger, Meta: Send + Serialize + DeserializeOwned> WalletStorage<'a,
 
             // Dynamic state
             txn_state: dynamic_state.txn_state,
-            key_scans: dynamic_state
-                .key_scans
-                .into_iter()
-                .map(|scan| (scan.address(), scan))
-                .collect(),
             key_state: dynamic_state.key_state,
 
             // Monotonic state
@@ -614,7 +604,6 @@ mod tests {
                 merkle_leaf_to_forget: None,
                 transactions: Default::default(),
             },
-            key_scans: Default::default(),
             key_state: Default::default(),
             assets: Default::default(),
             viewing_accounts: Default::default(),

--- a/src/testing/mocks.rs
+++ b/src/testing/mocks.rs
@@ -56,7 +56,6 @@ impl<'a> WalletStorage<'a, cap::Ledger> for MockStorage<'a> {
     ) -> Result<(), WalletError<cap::Ledger>> {
         if let Some(working) = &mut self.working {
             working.txn_state = state.txn_state.clone();
-            working.key_scans = state.key_scans.clone();
             working.key_state = state.key_state.clone();
 
             // Store updated accounts.
@@ -328,7 +327,6 @@ impl<'a> WalletBackend<'a, cap::Ledger> for MockBackend<'a> {
                     transactions: Default::default(),
                 },
                 key_state: Default::default(),
-                key_scans: Default::default(),
                 assets: Default::default(),
                 viewing_accounts: Default::default(),
                 freezing_accounts: Default::default(),

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -213,7 +213,6 @@ pub fn assert_wallet_states_eq<'a, L: Ledger>(w1: &WalletState<'a, L>, w2: &Wall
         w2.txn_state.record_mt.commitment()
     );
     assert_eq!(w1.txn_state.transactions, w2.txn_state.transactions);
-    assert_eq!(w1.key_scans, w2.key_scans);
 }
 
 #[async_trait]

--- a/src/testing/tests.rs
+++ b/src/testing/tests.rs
@@ -2427,6 +2427,7 @@ pub mod generic_wallet_tests {
                 assets: vec![],
                 records: vec![],
                 balance: 0,
+                scan_status: None,
             }
         );
         t.check_storage(&ledger, &wallets).await;
@@ -2470,6 +2471,7 @@ pub mod generic_wallet_tests {
                 assets: vec![],
                 records: vec![],
                 balance: 0,
+                scan_status: None,
             }
         );
         assert_eq!(
@@ -2481,6 +2483,7 @@ pub mod generic_wallet_tests {
                 assets: vec![],
                 records: vec![],
                 balance: 0,
+                scan_status: None,
             }
         );
         t.check_storage(&ledger, &wallets).await;


### PR DESCRIPTION
This makes it easy to provide a `scan_status` field of `AccountInfo`,
which clients can use to indicate when an account's balance may not
be up to date.