### PR TITLE
Add Seahorse version to wallet persistent storage.

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -37,6 +37,7 @@ pub trait WalletLoader<L: Ledger> {
 // DO NOT put secrets in here.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct LoaderMetadata {
+    version: (u8, u8, u8),
     salt: Salt,
     // Encrypted mnemonic phrase. This will only decrypt successfully if we have the correct
     // password, so we can use it as a quick check that the user entered the right thing.
@@ -277,6 +278,11 @@ impl<L: Ledger> WalletLoader<L> for Loader {
 
         let (salt, encrypted_mnemonic) = self.create_password(mnemonic)?;
         let meta = LoaderMetadata {
+            version: (
+                env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap(),
+                env!("CARGO_PKG_VERSION_MINOR").parse().unwrap(),
+                env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
+            ),
             salt,
             encrypted_mnemonic,
             encrypted_bytes,


### PR DESCRIPTION
This isn't a complete versioning solution, but it is at least an
escape hatch. If we ever need to push an update to a released product
that changes the format of persistent storage, the updated code can
check the first field of the wallet metadata and perform a migration
if it is out of date.

@bfish713 we should make sure this gets merged to whatever version
of Seahorse CAPE is using before people start using CAPE.