### PR TITLE
Pin All Dependencies to Tagged Versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,12 +132,12 @@ dependencies = [
 
 [[package]]
 name = "arbitrary-wrappers"
-version = "0.2.0"
-source = "git+https://github.com/EspressoSystems/arbitrary-wrappers.git#a6d0de1d283d1455eff666ca693ddda8e24fa422"
+version = "0.2.1"
+source = "git+https://github.com/EspressoSystems/arbitrary-wrappers.git?tag=0.2.1#f5218b1d0dd3caa0b45b0e17788056dd54409d67"
 dependencies = [
  "arbitrary",
  "ark-std",
- "espresso-macros 0.1.0 (git+https://github.com/EspressoSystems/espresso-macros.git?tag=0.1.0)",
+ "espresso-macros",
  "itertools",
  "jf-cap",
  "rand_chacha 0.3.1",
@@ -605,15 +605,15 @@ checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atomic_store"
-version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/atomicstore.git#b036409be09a472aa2fb54b1a138572df485fa1e"
+version = "0.1.1"
+source = "git+https://github.com/EspressoSystems/atomicstore.git?tag=0.1.1#e116cea2de934fd315f690d07d45b3bb7a213654"
 dependencies = [
  "ark-serialize",
  "bincode",
  "chrono",
  "glob",
  "serde",
- "snafu 0.7.0",
+ "snafu",
 ]
 
 [[package]]
@@ -1505,16 +1505,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "espresso-macros"
-version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-macros.git#9e0b0258c99757c567676c4dd92f1501db0cf580"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "event-listener"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,8 +2070,8 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jf-cap"
-version = "0.0.1"
-source = "git+https://github.com/EspressoSystems/cap.git#4c879a53fb46c8dec4a00f87c086fb5d29266c96"
+version = "0.0.2"
+source = "git+https://github.com/EspressoSystems/cap.git?tag=0.0.2#b64e513ec06714c681a9c5c70d04308b3f212a21"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2117,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "jf-plonk"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/jellyfish.git#1fc9a4861e39175a776dc8da109a0bdc1ebb1c5c"
+source = "git+https://github.com/EspressoSystems/jellyfish.git?tag=0.1.0#1fc9a4861e39175a776dc8da109a0bdc1ebb1c5c"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -2146,7 +2136,7 @@ dependencies = [
 [[package]]
 name = "jf-primitives"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/jellyfish.git#1fc9a4861e39175a776dc8da109a0bdc1ebb1c5c"
+source = "git+https://github.com/EspressoSystems/jellyfish.git?tag=0.1.0#1fc9a4861e39175a776dc8da109a0bdc1ebb1c5c"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -2168,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "jf-rescue"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/jellyfish.git#1fc9a4861e39175a776dc8da109a0bdc1ebb1c5c"
+source = "git+https://github.com/EspressoSystems/jellyfish.git?tag=0.1.0#1fc9a4861e39175a776dc8da109a0bdc1ebb1c5c"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -2193,7 +2183,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/jellyfish.git#1fc9a4861e39175a776dc8da109a0bdc1ebb1c5c"
+source = "git+https://github.com/EspressoSystems/jellyfish.git?tag=0.1.0#1fc9a4861e39175a776dc8da109a0bdc1ebb1c5c"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2204,14 +2194,14 @@ dependencies = [
  "jf-utils-derive",
  "serde",
  "sha2 0.10.2",
- "snafu 0.7.0",
- "tagged-base64",
+ "snafu",
+ "tagged-base64 0.1.0 (git+https://github.com/EspressoSystems/tagged-base64.git?branch=main)",
 ]
 
 [[package]]
 name = "jf-utils-derive"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/jellyfish.git#1fc9a4861e39175a776dc8da109a0bdc1ebb1c5c"
+source = "git+https://github.com/EspressoSystems/jellyfish.git?tag=0.1.0#1fc9a4861e39175a776dc8da109a0bdc1ebb1c5c"
 dependencies = [
  "ark-std",
  "quote",
@@ -2250,8 +2240,8 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "key-set"
-version = "0.2.0"
-source = "git+https://github.com/EspressoSystems/key-set.git#4d73b07b963c64c71c3bb94ad1422cee0d235fea"
+version = "0.2.1"
+source = "git+https://github.com/EspressoSystems/key-set.git?tag=0.2.1#324b24d107db537ce8c6f6439450795296b39c06"
 dependencies = [
  "ark-serialize",
  "bincode",
@@ -2260,7 +2250,7 @@ dependencies = [
  "jf-cap",
  "serde",
  "serde_with",
- "snafu 0.6.10",
+ "snafu",
 ]
 
 [[package]]
@@ -2416,8 +2406,8 @@ dependencies = [
 
 [[package]]
 name = "net"
-version = "0.2.0"
-source = "git+https://github.com/EspressoSystems/net.git#6e98531d741f8a37acabfadfd71d154bba4e61c4"
+version = "0.2.1"
+source = "git+https://github.com/EspressoSystems/net.git?tag=0.2.1#49f9503d5acd662ab5c4dc05d5b4db37e95b36f5"
 dependencies = [
  "ark-serialize",
  "ark-std",
@@ -2430,9 +2420,9 @@ dependencies = [
  "jf-utils",
  "serde",
  "serde_json",
- "snafu 0.6.10",
+ "snafu",
  "surf",
- "tagged-base64",
+ "tagged-base64 0.1.0 (git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.1.0)",
  "tide",
  "tracing",
 ]
@@ -3088,8 +3078,8 @@ dependencies = [
 
 [[package]]
 name = "reef"
-version = "0.2.0"
-source = "git+https://github.com/EspressoSystems/reef.git#eb6346a47ef941257dbb432fc1121419b2ad043c"
+version = "0.2.1"
+source = "git+https://github.com/EspressoSystems/reef.git?tag=0.2.1#4640c079c8bc7274dab7d7c47860697a19565240"
 dependencies = [
  "arbitrary",
  "arbitrary-wrappers",
@@ -3101,7 +3091,7 @@ dependencies = [
  "lazy_static",
  "rand_chacha 0.3.1",
  "serde",
- "snafu 0.7.0",
+ "snafu",
  "strum_macros",
 ]
 
@@ -3320,7 +3310,7 @@ dependencies = [
  "commit",
  "criterion",
  "derivative",
- "espresso-macros 0.1.0 (git+https://github.com/EspressoSystems/espresso-macros.git)",
+ "espresso-macros",
  "futures",
  "generic-array",
  "hmac 0.11.0",
@@ -3342,12 +3332,12 @@ dependencies = [
  "rustyline",
  "serde",
  "sha3 0.9.1",
- "snafu 0.7.0",
+ "snafu",
  "structopt",
  "strum",
  "strum_macros",
  "surf",
- "tagged-base64",
+ "tagged-base64 0.1.0 (git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.1.0)",
  "tempdir",
  "zeroize",
 ]
@@ -3592,35 +3582,13 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "snafu"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
-dependencies = [
- "backtrace",
- "doc-comment",
- "snafu-derive 0.6.10",
-]
-
-[[package]]
-name = "snafu"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eba135d2c579aa65364522eb78590cdf703176ef71ad4c32b00f58f7afb2df5"
 dependencies = [
  "backtrace",
  "doc-comment",
- "snafu-derive 0.7.0",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "snafu-derive",
 ]
 
 [[package]]
@@ -3838,6 +3806,22 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "tagged-base64"
+version = "0.1.0"
+source = "git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.1.0#204224e93ed31345e2e535c5da32072b38018b0c"
+dependencies = [
+ "base64 0.13.0",
+ "console_error_panic_hook",
+ "crc-any",
+ "futures-channel",
+ "js-sys",
+ "structopt",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2240,8 +2240,8 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "key-set"
-version = "0.2.1"
-source = "git+https://github.com/EspressoSystems/key-set.git?tag=0.2.1#324b24d107db537ce8c6f6439450795296b39c06"
+version = "0.2.2"
+source = "git+https://github.com/EspressoSystems/key-set.git?tag=0.2.2#c268c7b845635ef5e83108a4c987042eae160cbd"
 dependencies = [
  "ark-serialize",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ zeroize = "1.3"
 # local dependencies
 atomic_store = { git = "https://github.com/EspressoSystems/atomicstore.git", tag = "0.1.1" }
 commit = { git = "https://github.com/EspressoSystems/commit.git", tag = "0.1.0" }
-key-set = { git = "https://github.com/EspressoSystems/key-set.git", tag = "0.2.1" }
+key-set = { git = "https://github.com/EspressoSystems/key-set.git", tag = "0.2.2" }
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0" }
 jf-cap = { features=["std"], git = "https://github.com/EspressoSystems/cap.git", tag = "0.0.2" }
 jf-primitives = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,22 +43,22 @@ tempdir = "0.3.7"
 zeroize = "1.3"
 
 # local dependencies
-atomic_store = { git = "https://github.com/EspressoSystems/atomicstore.git" }
+atomic_store = { git = "https://github.com/EspressoSystems/atomicstore.git", tag = "0.1.1" }
 commit = { git = "https://github.com/EspressoSystems/commit.git", tag = "0.1.0" }
-key-set = { git = "https://github.com/EspressoSystems/key-set.git" }
-espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git" }
-jf-cap = { features=["std"], git = "https://github.com/EspressoSystems/cap.git" }
-jf-primitives = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git" }
-jf-utils = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git" }
-arbitrary-wrappers = { git = "https://github.com/EspressoSystems/arbitrary-wrappers.git" }
-net = { git = "https://github.com/EspressoSystems/net.git" }
-reef = { git = "https://github.com/EspressoSystems/reef.git" }
-tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", branch = "main" }
+key-set = { git = "https://github.com/EspressoSystems/key-set.git", tag = "0.2.1" }
+espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0" }
+jf-cap = { features=["std"], git = "https://github.com/EspressoSystems/cap.git", tag = "0.0.2" }
+jf-primitives = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.0" }
+jf-utils = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.0" }
+arbitrary-wrappers = { git = "https://github.com/EspressoSystems/arbitrary-wrappers.git", tag = "0.2.1" }
+net = { git = "https://github.com/EspressoSystems/net.git", tag = "0.2.1" }
+reef = {  git = "https://github.com/EspressoSystems/reef.git", tag = "0.2.1" }
+tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", tag = "0.1.0" }
 
 [dev-dependencies]
 criterion = {version = "0.3.3", features = ["async_std", "html_reports", "cargo_bench_support", "csv_output"] }
 proptest = "0.8.7"
-reef = { git = "https://github.com/EspressoSystems/reef.git", features = ["testing"] }
+reef = { git = "https://github.com/EspressoSystems/reef.git", tag = "0.2.1", features = ["testing"] }
 
 [features]
 testing = ["proptest", "criterion", "reef/testing"]


### PR DESCRIPTION
Pin everything to a released version before we release a Seahorse version.

Final step after this is to update CAPE to match these dependencies.