### PR TITLE
Replace UserAddress with UserPubKey for transfer and minting

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1199,7 +1199,7 @@ mod test {
             &[format!("{} {}", viewer_address, 1000)],
         );
 
-        // Get the sender's funded address.
+        // Get the sender's funded public key and address.
         writeln!(sender_input, "gen_key sending scan_from=start wait=true").unwrap();
         let matches = match_output(
             &mut sender_output,
@@ -1213,7 +1213,7 @@ mod test {
             &[format!("{} {}", sender_address, 1000)],
         );
 
-        // Get the receiver's (unfunded) address.
+        // Get the receiver's (unfunded) public key and address.
         writeln!(receiver_input, "gen_key sending").unwrap();
         let matches = match_output(
             &mut receiver_output,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -500,7 +500,7 @@ fn init_commands<'a, C: CLI<'a>>() -> Vec<Command<'a, C>> {
         ),
         command!(
             transfer,
-            "transfer some owned assets to another user",
+            "transfer some owned assets to another user's public key",
             C,
             |io, keystore, asset: ListItem<AssetCode>, to: UserPubKey, amount: u64, fee: u64; wait: Option<bool>| {
                 let res = keystore.transfer(None, &asset.item, &[(to, amount)], fee).await;
@@ -509,7 +509,7 @@ fn init_commands<'a, C: CLI<'a>>() -> Vec<Command<'a, C>> {
         ),
         command!(
             transfer_from,
-            "transfer some assets from an owned address to another user",
+            "transfer some assets from an owned address to another user's public key",
             C,
             |io, keystore, asset: ListItem<AssetCode>, from: UserAddress, to: UserPubKey, amount: u64, fee: u64; wait: Option<bool>| {
                 let res = keystore.transfer(Some(&from.0), &asset.item, &[(to, amount)], fee).await;
@@ -573,7 +573,7 @@ fn init_commands<'a, C: CLI<'a>>() -> Vec<Command<'a, C>> {
         ),
         command!(
             mint,
-            "mint an asset",
+            "mint an asset from an owned address to a user's public key",
             C,
             |io, keystore, asset: ListItem<AssetCode>, from: UserAddress, to: UserPubKey, amount: u64, fee: u64; wait: Option<bool>| {
                 let res = keystore.mint(&from.0, fee, &asset.item, amount, to).await;
@@ -582,7 +582,7 @@ fn init_commands<'a, C: CLI<'a>>() -> Vec<Command<'a, C>> {
         ),
         command!(
             freeze,
-            "freeze assets owned by another users",
+            "freeze assets owned by another user's address",
             C,
             |io, keystore, asset: ListItem<AssetCode>, fee_account: UserAddress, target: UserAddress,
              amount: U256, fee: u64; wait: Option<bool>|
@@ -593,7 +593,7 @@ fn init_commands<'a, C: CLI<'a>>() -> Vec<Command<'a, C>> {
         ),
         command!(
             unfreeze,
-            "unfreeze previously frozen assets owned by another users",
+            "unfreeze previously frozen assets owned by another user's address",
             C,
             |io, keystore, asset: ListItem<AssetCode>, fee_account: UserAddress, target: UserAddress,
              amount: U256, fee: u64; wait: Option<bool>|
@@ -1047,6 +1047,14 @@ async fn repl<'a, L: 'static + Ledger, C: CLI<'a, Ledger = L>>(
             for command in commands.iter() {
                 cli_writeln!(io, "{}", command);
             }
+            cli_writeln!(
+                io,
+                "General rule: When determining whether to use UserAddress or UserPubKey as the
+                parameter, use UserAddress as an account identifier (to send an asset, get a
+                balance, etc.), and UserPubKey as a transaction destination. An exception is when
+                we can't reasonably know the UserPubKey of the destination (freezing or
+                unfreezing), in which case we use UserAddress instead."
+            );
             continue;
         }
         for Command { name, run, .. } in commands.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2212,7 +2212,7 @@ impl<'a, L: 'static + Ledger, Backend: 'a + KeystoreBackend<'a, L> + Send + Sync
         let spec = TransferSpec {
             sender_key_pairs: &sender_key_pairs,
             asset,
-            receivers: &receivers,
+            receivers,
             fee,
             bound_data,
             xfr_size_requirement,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,11 +52,7 @@ use async_std::task::block_on;
 use async_trait::async_trait;
 use core::fmt::Debug;
 use espresso_macros::ser_test;
-use futures::{
-    channel::oneshot,
-    prelude::*,
-    stream::{iter, Stream},
-};
+use futures::{channel::oneshot, prelude::*, stream::Stream};
 use jf_cap::{
     errors::TxnApiError,
     freeze::FreezeNote,
@@ -2207,12 +2203,6 @@ impl<'a, L: 'static + Ledger, Backend: 'a + KeystoreBackend<'a, L> + Send + Sync
         xfr_size_requirement: Option<(usize, usize)>,
     ) -> Result<(TransferNote, TransactionInfo<L>), KeystoreError<L>> {
         let KeystoreSharedState { state, session, .. } = &mut *self.mutex.lock().await;
-        let receivers = iter(receivers)
-            .then(|(pub_key, amt, burn)| async move {
-                Ok::<_, KeystoreError<L>>((pub_key.clone(), *amt, *burn))
-            })
-            .try_collect::<Vec<_>>()
-            .await?;
         let sender_key_pairs = match sender {
             Some(addr) => {
                 vec![state.account_key_pair(addr)?.clone()]

--- a/src/testing/bench.rs
+++ b/src/testing/bench.rs
@@ -128,7 +128,7 @@ async fn generate_independent_transactions<
                     .unwrap();
                 let (mint_note, mint_info) = keystore
                     .build_mint(
-                        &pub_keys[0].0,
+                        &pub_keys[0].address(),
                         1,
                         &asset.code,
                         1u64 << 32,

--- a/src/testing/bench.rs
+++ b/src/testing/bench.rs
@@ -110,7 +110,7 @@ async fn generate_independent_transactions<
     let viewing_key = ViewerKeyPair::generate(&mut rng);
     let freezing_key = FreezerKeyPair::generate(&mut rng);
     let (assets, mints): (Vec<_>, Vec<_>) = join_all(keystores.iter_mut().enumerate().map(
-        |(i, (keystore, addrs))| {
+        |(i, (keystore, pub_keys))| {
             let viewing_key = viewing_key.pub_key();
             let freezing_key = freezing_key.pub_key();
             async move {
@@ -127,7 +127,13 @@ async fn generate_independent_transactions<
                     .await
                     .unwrap();
                 let (mint_note, mint_info) = keystore
-                    .build_mint(&addrs[0], 1, &asset.code, 1u64 << 32, addrs[0].clone())
+                    .build_mint(
+                        &pub_keys[0].0,
+                        1,
+                        &asset.code,
+                        1u64 << 32,
+                        pub_keys[0].clone(),
+                    )
                     .await
                     .unwrap();
                 let receipt = keystore
@@ -151,7 +157,7 @@ async fn generate_independent_transactions<
             .iter_mut()
             .zip(&assets)
             .map(|((keystore, _), asset)| {
-                let receiver = receiver.address();
+                let receiver = receiver.pub_key();
                 async move {
                     keystore
                         .build_transfer(

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -391,7 +391,7 @@ pub trait SystemUnderTest<'a>: Default + Send + Sync {
             )
             .await
             .unwrap();
-            let mut addresses = vec![];
+            let mut pub_keys = vec![];
             for key_pair in key_pairs.clone() {
                 assert_eq!(
                     keystore
@@ -404,9 +404,9 @@ pub trait SystemUnderTest<'a>: Default + Send + Sync {
                 // Wait for the keystore to find any records already belonging to this key from the
                 // initial grants.
                 keystore.await_key_scan(&key_pair.address()).await.unwrap();
-                addresses.push(key_pair);
+                pub_keys.push(key_pair.pub_key());
             }
-            keystores.push((keystore, addresses));
+            keystores.push((keystore, pub_keys));
         }
 
         println!("Keystores set up: {}s", now.elapsed().as_secs_f32());

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -260,10 +260,10 @@ pub trait SystemUnderTest<'a>: Default + Send + Sync {
         Keystore::with_state(backend, state).await.unwrap()
     }
 
-    /// Creates two key pairs/addresses for each keystore.
+    /// Creates two key pairs for each keystore.
     ///
     /// `initial_grants` - List of total initial grants for each keystore. Each amount will be
-    /// divided by 2, and any remainder will be added to the second address.
+    /// divided by 2, and any remainder will be added to the second public key.
     async fn create_test_network(
         &mut self,
         xfr_sizes: &[(usize, usize)],
@@ -273,7 +273,7 @@ pub trait SystemUnderTest<'a>: Default + Send + Sync {
         Arc<Mutex<MockLedger<'a, Self::Ledger, Self::MockNetwork, Self::MockStorage>>>,
         Vec<(
             Keystore<'a, Self::MockBackend, Self::Ledger>,
-            Vec<UserAddress>,
+            Vec<UserPubKey>,
         )>,
     ) {
         let mut rng = ChaChaRng::from_seed([42u8; 32]);
@@ -404,7 +404,7 @@ pub trait SystemUnderTest<'a>: Default + Send + Sync {
                 // Wait for the keystore to find any records already belonging to this key from the
                 // initial grants.
                 keystore.await_key_scan(&key_pair.address()).await.unwrap();
-                addresses.push(key_pair.address());
+                addresses.push(key_pair);
             }
             keystores.push((keystore, addresses));
         }
@@ -423,7 +423,7 @@ pub trait SystemUnderTest<'a>: Default + Send + Sync {
         ledger: &Arc<Mutex<MockLedger<'a, Self::Ledger, Self::MockNetwork, Self::MockStorage>>>,
         keystores: &[(
             Keystore<'a, Self::MockBackend, Self::Ledger>,
-            Vec<UserAddress>,
+            Vec<UserPubKey>,
         )],
     ) {
         let memos_source = {
@@ -484,7 +484,7 @@ pub trait SystemUnderTest<'a>: Default + Send + Sync {
         &self,
         keystores: &[(
             Keystore<'a, Self::MockBackend, Self::Ledger>,
-            Vec<UserAddress>,
+            Vec<UserPubKey>,
         )],
         t: EventIndex,
     ) {
@@ -497,7 +497,7 @@ pub trait SystemUnderTest<'a>: Default + Send + Sync {
         ledger: &Arc<Mutex<MockLedger<'a, Self::Ledger, Self::MockNetwork, Self::MockStorage>>>,
         keystores: &[(
             Keystore<'a, Self::MockBackend, Self::Ledger>,
-            Vec<UserAddress>,
+            Vec<UserPubKey>,
         )],
     ) {
         let ledger = ledger.lock().await;

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -18,7 +18,7 @@
 use super::*;
 use async_std::sync::{Arc, Mutex};
 use chrono::Local;
-use futures::channel::mpsc;
+use futures::{channel::mpsc, stream::iter};
 use jf_cap::{MerkleTree, Signature, TransactionVerifyingKey};
 use key_set::{KeySet, OrderByOutputs, ProverKeySet, VerifierKeySet};
 use rand_chacha::rand_core::RngCore;

--- a/src/testing/tests.rs
+++ b/src/testing/tests.rs
@@ -3045,8 +3045,10 @@ pub mod generic_keystore_tests {
         let (ledger, mut keystores) = t.create_test_network(&[(4, 4)], vec![8, 0], &mut now).await;
         ledger.lock().await.set_block_size(1).unwrap();
 
-        let addr0 = keystores[0].1[0].clone();
-        let addr1 = keystores[1].1[0].clone();
+        let pub_key0 = keystores[0].1[0].clone();
+        let addr0 = pub_key0.address();
+        let pub_key1 = keystores[1].1[0].clone();
+        let addr1 = pub_key1.address();
 
         // Define a mintable asset type.
         let asset = keystores[0]
@@ -3054,23 +3056,24 @@ pub mod generic_keystore_tests {
             .define_asset("my_asset".into(), &[], AssetPolicy::default())
             .await
             .unwrap();
+
         // Mint the maximum single-record amount, thrice (which will cause a total amount which
         // exceeds both the max single-record amount and the max of a u64).
         keystores[0]
             .0
-            .mint(&addr0, 1, &asset.code, max_record, addr0.clone())
+            .mint(&addr0, 1, &asset.code, max_record, pub_key0.clone())
             .await
             .unwrap();
         t.sync(&ledger, &keystores).await;
         keystores[0]
             .0
-            .mint(&addr0, 1, &asset.code, max_record, addr0.clone())
+            .mint(&addr0, 1, &asset.code, max_record, pub_key0.clone())
             .await
             .unwrap();
         t.sync(&ledger, &keystores).await;
         keystores[0]
             .0
-            .mint(&addr0, 1, &asset.code, max_record, addr0.clone())
+            .mint(&addr0, 1, &asset.code, max_record, pub_key0.clone())
             .await
             .unwrap();
         t.sync(&ledger, &keystores).await;
@@ -3103,7 +3106,10 @@ pub mod generic_keystore_tests {
             .transfer(
                 Some(&addr0),
                 &asset.code,
-                &[(addr1.clone(), max_record), (addr1.clone(), max_record)],
+                &[
+                    (pub_key1.clone(), max_record),
+                    (pub_key1.clone(), max_record),
+                ],
                 1,
             )
             .await


### PR DESCRIPTION
- Replaces the receiver's `UserAddress` with `UserPubKey` for transfer and minting.
- Updates tests and CLI.

Closes https://github.com/EspressoSystems/seahorse/issues/118.