### PR TITLE
Refactor loader implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,7 +2152,7 @@ dependencies = [
  "jf-plonk",
  "jf-primitives",
  "jf-rescue",
- "jf-utils 0.1.1",
+ "jf-utils",
  "num_cpus",
  "percentage",
  "rand 0.8.5",
@@ -2186,7 +2186,7 @@ dependencies = [
  "downcast-rs",
  "itertools",
  "jf-rescue",
- "jf-utils 0.1.1",
+ "jf-utils",
  "merlin",
  "num-bigint 0.4.3",
  "rand_chacha 0.3.1",
@@ -2216,7 +2216,7 @@ dependencies = [
  "itertools",
  "jf-plonk",
  "jf-rescue",
- "jf-utils 0.1.1",
+ "jf-utils",
  "rand_chacha 0.3.1",
  "rayon",
  "serde",
@@ -2243,28 +2243,10 @@ dependencies = [
  "derivative",
  "displaydoc",
  "generic-array",
- "jf-utils 0.1.1",
+ "jf-utils",
  "rayon",
  "serde",
  "zeroize",
-]
-
-[[package]]
-name = "jf-utils"
-version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/jellyfish.git?tag=0.1.0#1fc9a4861e39175a776dc8da109a0bdc1ebb1c5c"
-dependencies = [
- "anyhow",
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
- "digest 0.10.3",
- "jf-utils-derive 0.1.0",
- "serde",
- "sha2 0.10.2",
- "snafu",
- "tagged-base64 0.2.0 (git+https://github.com/EspressoSystems/tagged-base64.git?branch=main)",
 ]
 
 [[package]]
@@ -2278,21 +2260,11 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "digest 0.10.3",
- "jf-utils-derive 0.1.1",
+ "jf-utils-derive",
  "serde",
  "sha2 0.10.2",
  "snafu",
- "tagged-base64 0.2.0 (git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.0)",
-]
-
-[[package]]
-name = "jf-utils-derive"
-version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/jellyfish.git?tag=0.1.0#1fc9a4861e39175a776dc8da109a0bdc1ebb1c5c"
-dependencies = [
- "ark-std",
- "quote",
- "syn",
+ "tagged-base64",
 ]
 
 [[package]]
@@ -2503,8 +2475,8 @@ dependencies = [
 
 [[package]]
 name = "net"
-version = "0.3.0"
-source = "git+https://github.com/EspressoSystems/net.git#1bbfad0236758b3202eec30893c01cf501eaf0eb"
+version = "0.3.1"
+source = "git+https://github.com/EspressoSystems/net.git#0e204c8e5fb9416c2e779d8a33280fb47bcd0a75"
 dependencies = [
  "ark-serialize",
  "ark-std",
@@ -2514,12 +2486,12 @@ dependencies = [
  "generic-array",
  "itertools",
  "jf-cap",
- "jf-utils 0.1.0",
+ "jf-utils",
  "serde",
  "serde_json",
  "snafu",
  "surf",
- "tagged-base64 0.1.0",
+ "tagged-base64",
  "tide",
  "tracing",
 ]
@@ -3474,7 +3446,7 @@ dependencies = [
  "itertools",
  "jf-cap",
  "jf-primitives",
- "jf-utils 0.1.1",
+ "jf-utils",
  "key-set",
  "lazy_static",
  "net",
@@ -3483,6 +3455,7 @@ dependencies = [
  "pipe",
  "primitive-types",
  "proptest",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "reef",
  "regex",
@@ -3496,7 +3469,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "surf",
- "tagged-base64 0.2.0 (git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.0)",
+ "tagged-base64",
  "tempdir",
  "zeroize",
 ]
@@ -3975,40 +3948,8 @@ dependencies = [
 
 [[package]]
 name = "tagged-base64"
-version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.1.0#204224e93ed31345e2e535c5da32072b38018b0c"
-dependencies = [
- "base64 0.13.0",
- "console_error_panic_hook",
- "crc-any",
- "futures-channel",
- "js-sys",
- "structopt",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "tagged-base64"
 version = "0.2.0"
 source = "git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.0#c393e135a14a585707012fe2d7f9790f6c5f61d9"
-dependencies = [
- "base64 0.13.0",
- "console_error_panic_hook",
- "crc-any",
- "futures-channel",
- "js-sys",
- "structopt",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "tagged-base64"
-version = "0.2.0"
-source = "git+https://github.com/EspressoSystems/tagged-base64.git?branch=main#c393e135a14a585707012fe2d7f9790f6c5f61d9"
 dependencies = [
  "base64 0.13.0",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", 
 [dev-dependencies]
 criterion = {version = "0.3.3", features = ["async_std", "html_reports", "cargo_bench_support", "csv_output"] }
 proptest = "0.8.7"
+rand = "0.8.5"
 reef = { git = "https://github.com/EspressoSystems/reef.git", features = ["testing"] }
 
 [features]

--- a/src/hd.rs
+++ b/src/hd.rs
@@ -49,7 +49,7 @@ const SEED_LENGTH: usize = 16;
 pub type Salt = [u8; 32];
 
 /// A virtual tree of keys.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct KeyTree {
     // Sub-trees are 64 bytes, twice as large as the actual keys, to make it much harder to break
     // security upwards through the tree. This is probably not strictly necessary (32 bytes is

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -134,14 +134,15 @@ pub trait KeystoreLoader<L: Ledger> {
 /// password and salt. At this point, the user is able to log into their keystore through the normal
 /// login flow, using only the new password.
 ///
-/// When the keystore files are not available, recovery is exactly the same as creating a new wallet
-/// using the owner's original mnemonic phrase and a new password. It is then incumbent upon the
-/// owner of the wallet to regenerate their keys. If they used the correct mnemonic, the new keys
-/// will be the same keys that were generated in the original wallet, and they will be able to
-/// recover access to their on-chain assets. Note, however, that off-chain metadata that was stored
-/// in the lost keystore files cannot be recovered this way. Also note that since the original
-/// metadata is not available in this case, there is no way to report an error if the user enters
-/// the wrong mnemonic. If they do, they will simply be unable to recover their on-chain assets.
+/// When the keystore files are not available, recovery is exactly the same as creating a new
+/// keystore using the owner's original mnemonic phrase and a new password. It is then incumbent
+/// upon the owner of the keystore to regenerate their keys. If they used the correct mnemonic, the
+/// new keys will be the same keys that were generated in the original keystore, and they will be
+/// able to recover access to their on-chain assets. Note, however, that off-chain metadata that was
+/// stored in the lost keystore files cannot be recovered this way. Also note that since the
+/// original metadata is not available in this case, there is no way to report an error if the user
+/// enters the wrong mnemonic. If they do, they will simply be unable to recover their on-chain
+/// assets.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct MnemonicPasswordLogin {
     version: (u8, u8, u8),

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -8,35 +8,142 @@
 //! Traits and types for creating and loading keystores.
 //!
 //! This module defines the [KeystoreLoader] interface, which allows various implementations as
-//! plugins to the persistence layer. It also provides a generally useful implementation [Loader],
-//! which loads an encrypted keystore from the file system using a mnemonic phrase to generate keys
-//! and a password to provide a more convenient login interface.
-use super::{encryption, hd, reader, EncryptionSnafu, KeySnafu, KeystoreError, MnemonicSnafu};
-use encryption::{Cipher, CipherText, Salt};
-use hd::{KeyTree, Mnemonic};
+//! plugins to the persistence layer. It also provides a ew generally useful implementations based
+//! on the [MnemonicPasswordLogin] mechanism:
+//!
+//! * [InteractiveLoader]
+//! * [CreateLoader]
+//! * [LoginLoader]
+//! * [RecoveryLoader]
+
+use crate::{
+    encryption::{Cipher, CipherText},
+    hd::{KeyTree, Mnemonic, Salt},
+    EncryptionSnafu, KeySnafu, KeystoreError, Ledger,
+};
 use rand_chacha::{
     rand_core::{RngCore, SeedableRng},
     ChaChaRng,
 };
-use reader::Reader;
-use reef::Ledger;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
+
+pub mod create;
+pub mod interactive;
+pub mod login;
+pub mod recovery;
+
+#[cfg(test)]
+mod tests;
+
+pub use create::CreateLoader;
+pub use interactive::InteractiveLoader;
+pub use login::LoginLoader;
+pub use recovery::RecoveryLoader;
 
 pub trait KeystoreLoader<L: Ledger> {
-    type Meta; // Metadata stored in plaintext and used by the loader to access the keystore.
+    /// Metadata about a keystore which is always stored unencrypted.
+    ///
+    /// This allows loaders and tools to report some basic information about the keystore and handle
+    /// login attempts without decrypting.
+    ///
+    /// DO NOT put secrets in here.
+    type Meta;
+
+    /// The location of the keystore targetted by this loader.
+    ///
+    /// This tells users of the loader, like
+    /// [AtomicKeystoreStorage](crate::persistence::AtomicKeystoreStorage), where to load existing
+    /// metadata from when calling [load](Self::load).
     fn location(&self) -> PathBuf;
+
+    /// Create a new keystore.
+    ///
+    /// The caller must ensure that no keystore currently exists at `self.location()`. The loader
+    /// will create the metadata for a new keystore and return it, along with the key tree to use
+    /// when deriving keys for the new keystore. The caller should persist the new metadata in
+    /// `self.location()`.
     fn create(&mut self) -> Result<(Self::Meta, KeyTree), KeystoreError<L>>;
+
+    /// Load an existing keystore.
+    ///
+    /// The caller must have loaded `meta` from `self.location()`. The loader will use `meta` to
+    /// authenticate the keystore and derive the key tree, which is used to decrypt the rest of the
+    /// keystore files and derive new keys.
+    ///
+    /// The loader may change `meta`. For instance, some loaders allow the owner of a keystore to
+    /// log in using a mnemonic phrase and reset the password. In this case, `meta` would be updated
+    /// with a new password. If the value of `meta` after this call succeeds is not equal to its
+    /// value before the call, the caller is responsible for persisting the new value in
+    /// `self.location()`.
+    ///
+    /// If [load](Self::load) fails, it will not change `meta`.
     fn load(&mut self, meta: &mut Self::Meta) -> Result<KeyTree, KeystoreError<L>>;
 }
 
-// Metadata about a keystore which is always stored unencrypted, so we can report some basic
-// information about the keystore without decrypting. This also aids in the key derivation process.
-//
-// DO NOT put secrets in here.
+/// Metadata that supports login with a password and backup/recovery with a mnemonic.
+///
+/// Like all Seahorse keystores, a keystore using [MnemonicPasswordLogin] is ultimately derived from
+/// a mnemonic phrase. This phrase can be used later on to recover the keystore if the owner loses
+/// access to the encrypted keystore files or forgets their password. In addition, keystores that
+/// use [MnemonicPasswordLogin] have a password which can be used to decrypt the keystore files
+/// without having to type in the entire unwieldy mnemonic phrase.
+///
+/// The contents of the [MnemonicPasswordLogin] metadata are:
+/// * a version header
+/// * a 32-byte salt, which is randomly generated when the keystore is created
+/// * the keystore's mnemonic phrase, securely encrypted
+/// * random bytes (sampled when the keystore is created) encrypted and authenticated using a key
+///   derived from the mnemonic
+///
+/// This data is used throughout the keystore lifecycle as follows.
+///
+/// ## Creation
+///
+/// When a new keystore is created, a mnemonic phrase is sampled randomly and the owner provides a
+/// password. The loader then samples 32 bytes of salt which, combined with the password, derives an
+/// encryption key that is used to encrypt the mnemonic. Storing the mnemonic, encrypted under the
+/// password, is how we facilitate convenient login, as we will soon see.
+///
+/// We also store 32 random bytes, encrypted and authenticated using a key derived from the mnemonic
+/// phrase. This allows applications to check whether a mnemonic phrase is the correct one for this
+/// keystore without having access to the password to decrypt the mnemonic: if the random bytes
+/// successfully decrypt using the key derived from the potential mnemonic, then it is the correct
+/// one. This is especially useful when attempting to recover a keystore from a mnemonic.
+///
+/// ## Login
+///
+/// To log in to a keystore, the owner must provide the password. They need not provide the
+/// mnemonic. The loader uses the password and the salt stored in the metadata to derive a
+/// decryption key, and then decrypts the mnemonic phrase, which was stored encrypted in the
+/// metadata. Keys derived from the mnemonic phrase can then be used to decrypt the rest of the
+/// keystore files and access the owner's assets.
+///
+/// ## Recovery
+///
+/// There are two cases of recovery: recovering access to encrypted keystore files after forgetting
+/// the password, or recovering a keystore whose files have been lost. [MnemonicPasswordLogin]
+/// supports both cases. Recovery is slower without the keystore files, but no less effective.
+///
+/// When the keystore files are available, the owner's mnemonic phrase can be used to derive the
+/// keys necessary to decrypt them. In this case, the random bytes encrypted using the mnemonic
+/// phrase and stored in the metadata are used to quickly report an error if the user provides an
+/// incorrect mnemonic phrase. If decryption is successful, the user may provide a new password, and
+/// the loader will sample a new random salt and re-encrypt the mnemonic phrase using the new
+/// password and salt. At this point, the user is able to log into their keystore through the normal
+/// login flow, using only the new password.
+///
+/// When the keystore files are not available, recovery is exactly the same as creating a new wallet
+/// using the owner's original mnemonic phrase and a new password. It is then incumbent upon the
+/// owner of the wallet to regenerate their keys. If they used the correct mnemonic, the new keys
+/// will be the same keys that were generated in the original wallet, and they will be able to
+/// recover access to their on-chain assets. Note, however, that off-chain metadata that was stored
+/// in the lost keystore files cannot be recovered this way. Also note that since the original
+/// metadata is not available in this case, there is no way to report an error if the user enters
+/// the wrong mnemonic. If they do, they will simply be unable to recover their on-chain assets.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct LoaderMetadata {
+pub struct MnemonicPasswordLogin {
     version: (u8, u8, u8),
     salt: Salt,
     // Encrypted mnemonic phrase. This will only decrypt successfully if we have the correct
@@ -44,240 +151,33 @@ pub struct LoaderMetadata {
     encrypted_mnemonic: CipherText,
     // Encrypted random bytes using a key generated from the mnemonic phrase. This will only decrypt
     // suffessfully if we have the correct mnemonic, so it can be used to check the user's input
-    // when recoverying from a mnemonic.
+    // when recovering from a mnemonic.
     encrypted_bytes: CipherText,
 }
 
-enum LoaderInput {
-    User(Reader),
-    PasswordLiteral(String),
-    RecoveryLiteral(String, String),
-    MnemonicPasswordLiteral(String, String),
-}
+impl MnemonicPasswordLogin {
+    const KEY_CHECK_SUB_TREE: &'static str = "key_check";
 
-impl LoaderInput {
-    fn create_password<L: Ledger>(&mut self) -> Result<String, KeystoreError<L>> {
-        match self {
-            Self::User(reader) => loop {
-                let password = reader.read_password("Create password: ")?;
-                let confirm = reader.read_password("Retype password: ")?;
-                if password == confirm {
-                    return Ok(password);
-                } else {
-                    println!("Passwords do not match.");
-                }
-            },
-
-            Self::PasswordLiteral(password)
-            | Self::MnemonicPasswordLiteral(_, password)
-            | Self::RecoveryLiteral(_, password) => Ok(password.to_string()),
-        }
-    }
-
-    fn read_password<L: Ledger>(&mut self) -> Result<Option<String>, KeystoreError<L>> {
-        match self {
-            Self::User(reader) => loop {
-                println!("Forgot your password? Want to change it? [y/n]");
-                match reader.read_line() {
-                    Some(line) => match line.as_str().trim() {
-                        "n" => break Ok(Some(reader.read_password("Enter password: ")?)),
-                        "y" => break Ok(None),
-                        _ => println!("Please enter 'y' or 'n'."),
-                    },
-                    None => {
-                        return Err(KeystoreError::Failed {
-                            msg: String::from("eof"),
-                        })
-                    }
-                }
-            },
-            Self::PasswordLiteral(password) => Ok(Some(password.to_string())),
-            Self::MnemonicPasswordLiteral(_, password) => Ok(Some(password.to_string())),
-            Self::RecoveryLiteral(_, _) => Ok(None),
-        }
-    }
-
-    fn create_mnemonic<L: Ledger>(
-        &mut self,
+    /// Create new login metadata with a given mnemonic phrase and password.
+    pub fn new<L: Ledger>(
         rng: &mut ChaChaRng,
-    ) -> Result<Mnemonic, KeystoreError<L>> {
-        match self {
-            Self::User(reader) => {
-                println!(
-                    "Your keystore will be identified by a secret mnemonic phrase. This phrase will \
-                     allow you to recover your keystore if you lose access to it. Anyone who has access \
-                     to this phrase will be able to view and spend your assets. Store this phrase in a \
-                     safe, private place."
-                );
-                'outer: loop {
-                    let (_, mnemonic) = KeyTree::random(rng);
-                    println!("Your mnemonic phrase will be:");
-                    println!("{}", mnemonic);
-                    'inner: loop {
-                        println!("1) Accept phrase and create keystore");
-                        println!("2) Generate a new phrase");
-                        println!(
-                            "3) Manually enter a mnemonic (use this to recover a lost keystore)"
-                        );
-                        match reader.read_line() {
-                            Some(line) => match line.as_str().trim() {
-                                "1" => return Ok(mnemonic),
-                                "2" => continue 'outer,
-                                "3" => return Self::read_mnemonic_interactive(reader),
-                                _ => continue 'inner,
-                            },
-                            None => {
-                                return Err(KeystoreError::Failed {
-                                    msg: String::from("eof"),
-                                })
-                            }
-                        }
-                    }
-                }
-            }
-
-            Self::PasswordLiteral(_) => Err(KeystoreError::Failed {
-                msg: String::from("missing mnemonic phrase"),
-            }),
-
-            Self::MnemonicPasswordLiteral(mnemonic, _) | Self::RecoveryLiteral(mnemonic, _) => {
-                Mnemonic::from_phrase(mnemonic.as_str()).context(MnemonicSnafu)
-            }
-        }
-    }
-
-    fn read_mnemonic<L: Ledger>(&mut self) -> Result<Mnemonic, KeystoreError<L>> {
-        match self {
-            Self::User(reader) => Self::read_mnemonic_interactive(reader),
-            Self::PasswordLiteral(_) => Err(KeystoreError::Failed {
-                msg: String::from("missing mnemonic phrase"),
-            }),
-            Self::MnemonicPasswordLiteral(mnemonic, _) | Self::RecoveryLiteral(mnemonic, _) => {
-                Mnemonic::from_phrase(mnemonic.as_str()).context(MnemonicSnafu)
-            }
-        }
-    }
-
-    fn interactive(&self) -> bool {
-        matches!(self, Self::User(..))
-    }
-
-    fn read_mnemonic_interactive<L: Ledger>(
-        reader: &mut Reader,
-    ) -> Result<Mnemonic, KeystoreError<L>> {
-        loop {
-            let phrase = reader.read_password("Enter mnemonic phrase: ")?;
-            match Mnemonic::from_phrase(&phrase) {
-                Ok(mnemonic) => return Ok(mnemonic),
-                Err(err) => {
-                    println!("That's not a valid mnemonic phrase ({})", err);
-                }
-            }
-        }
-    }
-}
-
-pub struct Loader {
-    dir: PathBuf,
-    pub rng: ChaChaRng,
-    input: LoaderInput,
-}
-
-impl Loader {
-    pub fn new(dir: PathBuf, reader: Reader) -> Self {
-        Self {
-            dir,
-            input: LoaderInput::User(reader),
-            rng: ChaChaRng::from_entropy(),
-        }
-    }
-
-    pub fn from_literal(mnemonic: Option<String>, password: String, dir: PathBuf) -> Self {
-        match mnemonic {
-            Some(m) => Self {
-                dir,
-                input: LoaderInput::MnemonicPasswordLiteral(m, password),
-                rng: ChaChaRng::from_entropy(),
-            },
-            None => Self {
-                dir,
-                input: LoaderInput::PasswordLiteral(password),
-                rng: ChaChaRng::from_entropy(),
-            },
-        }
-    }
-
-    pub fn recovery(mnemonic: String, new_password: String, dir: PathBuf) -> Self {
-        Self {
-            dir,
-            input: LoaderInput::RecoveryLiteral(mnemonic, new_password),
-            rng: ChaChaRng::from_entropy(),
-        }
-    }
-
-    pub fn into_reader(self) -> Option<Reader> {
-        match self.input {
-            LoaderInput::User(reader) => Some(reader),
-            _ => None,
-        }
-    }
-
-    pub fn path(&self) -> &Path {
-        &self.dir
-    }
-
-    fn create_from_mnemonic<L: Ledger>(&mut self) -> Result<(Mnemonic, KeyTree), KeystoreError<L>> {
-        let mnemonic = self.input.create_mnemonic(&mut self.rng)?;
-        let key = KeyTree::from_mnemonic(&mnemonic);
-        Ok((mnemonic, key))
-    }
-
-    // Create a password, returning salt and encrypted mnemonic.
-    fn create_password<L: Ledger>(
-        &mut self,
-        mnemonic: Mnemonic,
-    ) -> Result<(Salt, CipherText), KeystoreError<L>> {
-        let password = self.input.create_password()?;
-
-        // Encrypt the mnemonic phrase, which we can decrypt on load to check the derived key.
-        let (encryption_key, salt) =
-            KeyTree::from_password(&mut self.rng, password.as_bytes()).context(KeySnafu)?;
-        let encrypted_mnemonic = Cipher::new(
-            encryption_key.derive_sub_tree(KEY_CHECK_SUB_TREE.as_bytes()),
-            ChaChaRng::from_rng(&mut self.rng).unwrap(),
-        )
-        .encrypt(mnemonic.into_phrase().as_str().as_bytes())
-        .context(EncryptionSnafu)?;
-
-        Ok((salt, encrypted_mnemonic))
-    }
-}
-
-static KEY_CHECK_SUB_TREE: &str = "key_check";
-
-impl<L: Ledger> KeystoreLoader<L> for Loader {
-    type Meta = LoaderMetadata;
-
-    fn location(&self) -> PathBuf {
-        self.dir.clone()
-    }
-
-    fn create(&mut self) -> Result<(LoaderMetadata, KeyTree), KeystoreError<L>> {
-        let (mnemonic, key) = self.create_from_mnemonic()?;
+        mnemonic: &Mnemonic,
+        password: &[u8],
+    ) -> Result<Self, KeystoreError<L>> {
+        let (encrypted_mnemonic, salt) = Self::encrypt_mnemonic(rng, mnemonic, password)?;
 
         // Generate and encrypt some random bytes using the mnemonic, so in the future we can check
         // if the mnemonic is correct.
         let mut bytes = [0u8; 32];
-        self.rng.fill_bytes(&mut bytes);
+        rng.fill_bytes(&mut bytes);
         let encrypted_bytes = Cipher::new(
-            key.derive_sub_tree(KEY_CHECK_SUB_TREE.as_bytes()),
-            ChaChaRng::from_rng(&mut self.rng).unwrap(),
+            KeyTree::from_mnemonic(mnemonic).derive_sub_tree(Self::KEY_CHECK_SUB_TREE.as_bytes()),
+            Some(ChaChaRng::from_rng(rng).unwrap()),
         )
         .encrypt(&bytes)
         .context(EncryptionSnafu)?;
 
-        let (salt, encrypted_mnemonic) = self.create_password(mnemonic)?;
-        let meta = LoaderMetadata {
+        Ok(Self {
             version: (
                 env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap(),
                 env!("CARGO_PKG_VERSION_MINOR").parse().unwrap(),
@@ -286,66 +186,84 @@ impl<L: Ledger> KeystoreLoader<L> for Loader {
             salt,
             encrypted_mnemonic,
             encrypted_bytes,
-        };
-
-        Ok((meta, key))
+        })
     }
 
-    fn load(&mut self, meta: &mut Self::Meta) -> Result<KeyTree, KeystoreError<L>> {
-        let key = loop {
-            if let Some(password) = self.input.read_password()? {
-                // Generate the decryption key and check that we can use it to decrypt
-                // `encrypted_mnemonic`. If we can't, the key is wrong.
-                let decryption_key =
-                    KeyTree::from_password_and_salt(password.as_bytes(), &meta.salt)
-                        .context(KeySnafu)?;
-                if let Ok(mnemonic_bytes) = Cipher::new(
-                    decryption_key.derive_sub_tree(KEY_CHECK_SUB_TREE.as_bytes()),
-                    ChaChaRng::from_rng(&mut self.rng).unwrap(),
-                )
-                .decrypt(&meta.encrypted_mnemonic)
-                {
-                    // If the data decrypts successfully, then `mnemonic_bytes` is authenticated, so
-                    // we can safely unwrap when deserializing it.
-                    break KeyTree::from_mnemonic(
-                        &Mnemonic::from_phrase(std::str::from_utf8(&mnemonic_bytes).unwrap())
-                            .unwrap(),
-                    );
-                } else if self.input.interactive() {
-                    println!("Sorry, that's incorrect.");
-                } else {
-                    return Err(KeystoreError::Failed {
-                        msg: String::from("incorrect password"),
-                    });
-                }
-            } else {
-                // Reset password using mnemonic.
-                let mnemonic = self.input.read_mnemonic()?;
-                let key = KeyTree::from_mnemonic(&mnemonic);
+    /// Check if a password matches the one associated with this metadata.
+    pub fn check_password(&self, password: &[u8]) -> bool {
+        self.decrypt_mnemonic(password).is_some()
+    }
 
-                // Check if the entered mnemonic is correct by attempting to decrypt the encrypted
-                // random bytes.
-                if Cipher::new(
-                    key.derive_sub_tree(KEY_CHECK_SUB_TREE.as_bytes()),
-                    ChaChaRng::from_rng(&mut self.rng).unwrap(),
-                )
-                .decrypt(&meta.encrypted_bytes)
-                .is_ok()
-                {
-                    let (salt, encrypted_mnemonic) = self.create_password(mnemonic)?;
-                    meta.salt = salt;
-                    meta.encrypted_mnemonic = encrypted_mnemonic;
-                    break key;
-                } else if self.input.interactive() {
-                    println!("Sorry, that's incorrect.");
-                } else {
-                    return Err(KeystoreError::Failed {
-                        msg: String::from("incorrect mnemonic"),
-                    });
-                }
-            }
-        };
+    /// Check if a password phrase matches the one associated with this metadata.
+    pub fn check_mnemonic(&self, mnemonic: &Mnemonic) -> bool {
+        // Check if the mnemonic is correct by attempting to decrypt the random bytes.
+        Cipher::decrypter(
+            KeyTree::from_mnemonic(mnemonic).derive_sub_tree(Self::KEY_CHECK_SUB_TREE.as_bytes()),
+        )
+        .decrypt(&self.encrypted_bytes)
+        .is_ok()
+    }
 
-        Ok(key)
+    /// Decrypt the mnemonic phrase associated with this metadata.
+    ///
+    /// Returns `Some` mnemonic phrase if `password` is the correct one. Otherwise returns `None`.
+    pub fn decrypt_mnemonic(&self, password: &[u8]) -> Option<Mnemonic> {
+        // Generate the decryption key and check that we can use it to decrypt `encrypted_mnemonic`.
+        // If we can't, the key is wrong.
+        let decryption_key = KeyTree::from_password_and_salt(password, &self.salt).ok()?;
+        if let Ok(mnemonic_bytes) =
+            Cipher::decrypter(decryption_key.derive_sub_tree(Self::KEY_CHECK_SUB_TREE.as_bytes()))
+                .decrypt(&self.encrypted_mnemonic)
+        {
+            // If the data decrypts successfully, then `mnemonic_bytes` is authenticated, so we can
+            // safely unwrap when deserializing it.
+            Some(Mnemonic::from_phrase(std::str::from_utf8(&mnemonic_bytes).unwrap()).unwrap())
+        } else {
+            None
+        }
+    }
+
+    /// Change the password associated with this metadata.
+    ///
+    /// After this function succeeds, the new password may be used to log into the keystore with
+    /// this metadata, and the old password may no longer be used.
+    ///
+    /// If `mnemonic` is not the mnemonic phrase associated with this metadata, this function fails,
+    /// and the metadata is unchanged.
+    pub fn set_password<L: Ledger>(
+        &mut self,
+        rng: &mut ChaChaRng,
+        mnemonic: &Mnemonic,
+        new_password: &[u8],
+    ) -> Result<(), KeystoreError<L>> {
+        if !self.check_mnemonic(mnemonic) {
+            return Err(KeystoreError::Failed {
+                msg: String::from("incorrect mnemonic"),
+            });
+        }
+
+        // Encrypt the mnemonic phrase, which we can decrypt on load to check the derived key.
+        let (encrypted_mnemonic, salt) = Self::encrypt_mnemonic(rng, mnemonic, new_password)?;
+        self.encrypted_mnemonic = encrypted_mnemonic;
+        self.salt = salt;
+
+        Ok(())
+    }
+
+    fn encrypt_mnemonic<L: Ledger>(
+        rng: &mut ChaChaRng,
+        mnemonic: &Mnemonic,
+        password: &[u8],
+    ) -> Result<(CipherText, Salt), KeystoreError<L>> {
+        // Encrypt the mnemonic phrase, which we can decrypt on load to check the derived key.
+        let (encryption_key, salt) = KeyTree::from_password(rng, password).context(KeySnafu)?;
+        let encrypted_mnemonic = Cipher::new(
+            encryption_key.derive_sub_tree(Self::KEY_CHECK_SUB_TREE.as_bytes()),
+            Some(ChaChaRng::from_rng(rng).unwrap()),
+        )
+        .encrypt(mnemonic.phrase().as_bytes())
+        .context(EncryptionSnafu)?;
+
+        Ok((encrypted_mnemonic, salt))
     }
 }

--- a/src/loader/create.rs
+++ b/src/loader/create.rs
@@ -1,0 +1,87 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the Seahorse library.
+
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    hd::{KeyTree, Mnemonic},
+    loader::{KeystoreLoader, MnemonicPasswordLogin},
+    KeystoreError,
+};
+use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
+use reef::Ledger;
+use std::path::PathBuf;
+
+/// Create or log into a keystore using a given password and mnemonic.
+///
+/// This loader will attempt to create or log into a keystore using a given password and mnemonic.
+/// If no keystore exists, it will create one using the mnemonic and password. If one does exist, it
+/// will attempt to log in using the password, unless the loader was created with
+/// [CreateLoader::exclusive].
+pub struct CreateLoader {
+    mnemonic: Mnemonic,
+    password: String,
+    dir: PathBuf,
+    exclusive: bool,
+    rng: ChaChaRng,
+}
+
+impl CreateLoader {
+    pub fn new(rng: &mut ChaChaRng, dir: PathBuf, mnemonic: Mnemonic, password: String) -> Self {
+        Self {
+            dir,
+            mnemonic,
+            password,
+            exclusive: false,
+            rng: ChaChaRng::from_rng(rng).unwrap(),
+        }
+    }
+
+    /// A [CreateLoader] which fails if a keystore already exists.
+    pub fn exclusive(
+        rng: &mut ChaChaRng,
+        dir: PathBuf,
+        mnemonic: Mnemonic,
+        password: String,
+    ) -> Self {
+        Self {
+            dir,
+            mnemonic,
+            password,
+            exclusive: true,
+            rng: ChaChaRng::from_rng(rng).unwrap(),
+        }
+    }
+}
+
+impl<L: Ledger> KeystoreLoader<L> for CreateLoader {
+    type Meta = MnemonicPasswordLogin;
+
+    fn location(&self) -> PathBuf {
+        self.dir.clone()
+    }
+
+    fn create(&mut self) -> Result<(Self::Meta, KeyTree), KeystoreError<L>> {
+        let meta =
+            MnemonicPasswordLogin::new(&mut self.rng, &self.mnemonic, self.password.as_bytes())?;
+        let key = KeyTree::from_mnemonic(&self.mnemonic);
+        Ok((meta, key))
+    }
+
+    fn load(&mut self, meta: &mut Self::Meta) -> Result<KeyTree, KeystoreError<L>> {
+        if self.exclusive {
+            return Err(KeystoreError::Failed {
+                msg: String::from("using an exclusive CreateLoader with an existing wallet"),
+            });
+        }
+
+        let mnemonic = meta
+            .decrypt_mnemonic(self.password.as_bytes())
+            .ok_or_else(|| KeystoreError::Failed {
+                msg: String::from("incorrect password"),
+            })?;
+        Ok(KeyTree::from_mnemonic(&mnemonic))
+    }
+}

--- a/src/loader/create.rs
+++ b/src/loader/create.rs
@@ -73,7 +73,7 @@ impl<L: Ledger> KeystoreLoader<L> for CreateLoader {
     fn load(&mut self, meta: &mut Self::Meta) -> Result<KeyTree, KeystoreError<L>> {
         if self.exclusive {
             return Err(KeystoreError::Failed {
-                msg: String::from("using an exclusive CreateLoader with an existing wallet"),
+                msg: String::from("using an exclusive CreateLoader with an existing keystore"),
             });
         }
 

--- a/src/loader/interactive.rs
+++ b/src/loader/interactive.rs
@@ -1,0 +1,157 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the Seahorse library.
+
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    hd,
+    loader::{KeystoreLoader, MnemonicPasswordLogin},
+    reader, KeystoreError,
+};
+use hd::{KeyTree, Mnemonic};
+use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
+use reader::Reader;
+use reef::Ledger;
+use std::path::{Path, PathBuf};
+
+/// Load or a create a wallet with interactive, text-based login.
+///
+/// This loader will read from the given reader to gather configuration and authentication when
+/// creating or opening a wallet. It supports the creation of new wallets with a mnemonic recovery
+/// phrase and a password for convenience, as well as logging into existing wallets with a password.
+pub struct InteractiveLoader {
+    dir: PathBuf,
+    pub rng: ChaChaRng,
+    input: Reader,
+}
+
+impl InteractiveLoader {
+    pub fn new(dir: PathBuf, input: Reader) -> Self {
+        Self {
+            dir,
+            input,
+            rng: ChaChaRng::from_entropy(),
+        }
+    }
+
+    pub fn into_reader(self) -> Reader {
+        self.input
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.dir
+    }
+
+    fn create_password<L: Ledger>(&mut self) -> Result<String, KeystoreError<L>> {
+        loop {
+            let password = self.input.read_password("Create password: ")?;
+            let confirm = self.input.read_password("Retype password: ")?;
+            if password == confirm {
+                return Ok(password);
+            } else {
+                println!("Passwords do not match.");
+            }
+        }
+    }
+
+    fn read_mnemonic<L: Ledger>(&mut self) -> Result<Mnemonic, KeystoreError<L>> {
+        loop {
+            let phrase = self.input.read_password("Enter mnemonic phrase: ")?;
+            match Mnemonic::from_phrase(&phrase) {
+                Ok(mnemonic) => return Ok(mnemonic),
+                Err(err) => {
+                    println!("That's not a valid mnemonic phrase ({})", err);
+                }
+            }
+        }
+    }
+}
+
+impl<L: Ledger> KeystoreLoader<L> for InteractiveLoader {
+    type Meta = MnemonicPasswordLogin;
+
+    fn location(&self) -> PathBuf {
+        self.dir.clone()
+    }
+
+    fn create(&mut self) -> Result<(MnemonicPasswordLogin, KeyTree), KeystoreError<L>> {
+        println!(
+            "Your keystore will be identified by a secret mnemonic phrase. This phrase will \
+             allow you to recover your keystore if you lose access to it. Anyone who has access \
+             to this phrase will be able to view and spend your assets. Store this phrase in a \
+             safe, private place."
+        );
+        let mnemonic = 'outer: loop {
+            let (_, mnemonic) = KeyTree::random(&mut self.rng);
+            println!("Your mnemonic phrase will be:");
+            println!("{}", mnemonic);
+            'inner: loop {
+                println!("1) Accept phrase and create keystore");
+                println!("2) Generate a new phrase");
+                println!("3) Manually enter a mnemonic (use this to recover a lost keystore)");
+                match self.input.read_line() {
+                    Some(line) => match line.as_str().trim() {
+                        "1" => break 'outer (mnemonic),
+                        "2" => continue 'outer,
+                        "3" => break 'outer (self.read_mnemonic()?),
+                        _ => continue 'inner,
+                    },
+                    None => {
+                        return Err(KeystoreError::Failed {
+                            msg: String::from("eof"),
+                        })
+                    }
+                }
+            }
+        };
+        let key = KeyTree::from_mnemonic(&mnemonic);
+        let password = self.create_password()?;
+        let meta = MnemonicPasswordLogin::new(&mut self.rng, &mnemonic, password.as_bytes())?;
+
+        Ok((meta, key))
+    }
+
+    fn load(&mut self, meta: &mut Self::Meta) -> Result<KeyTree, KeystoreError<L>> {
+        let key = loop {
+            let password = loop {
+                println!("Forgot your password? Want to change it? [y/n]");
+                match self.input.read_line() {
+                    Some(line) => match line.as_str().trim() {
+                        "n" => break Some(self.input.read_password("Enter password: ")?),
+                        "y" => break None,
+                        _ => println!("Please enter 'y' or 'n'."),
+                    },
+                    None => {
+                        return Err(KeystoreError::Failed {
+                            msg: String::from("eof"),
+                        });
+                    }
+                }
+            };
+
+            if let Some(password) = password {
+                if let Some(mnemonic) = meta.decrypt_mnemonic(password.as_bytes()) {
+                    break KeyTree::from_mnemonic(&mnemonic);
+                } else {
+                    println!("Sorry, that's incorrect.");
+                }
+            } else {
+                // Reset password using mnemonic.
+                let mnemonic = self.read_mnemonic()?;
+                if meta.check_mnemonic(&mnemonic) {
+                    let password = self.create_password()?;
+                    // This should never fail after we have verified the mnemonic.
+                    meta.set_password::<L>(&mut self.rng, &mnemonic, password.as_bytes())
+                        .unwrap();
+                    break KeyTree::from_mnemonic(&mnemonic);
+                } else {
+                    println!("Sorry, that's incorrect.");
+                }
+            }
+        };
+
+        Ok(key)
+    }
+}

--- a/src/loader/interactive.rs
+++ b/src/loader/interactive.rs
@@ -16,11 +16,12 @@ use reader::Reader;
 use reef::Ledger;
 use std::path::{Path, PathBuf};
 
-/// Load or a create a wallet with interactive, text-based login.
+/// Load or a create a keystore with interactive, text-based login.
 ///
 /// This loader will read from the given reader to gather configuration and authentication when
-/// creating or opening a wallet. It supports the creation of new wallets with a mnemonic recovery
-/// phrase and a password for convenience, as well as logging into existing wallets with a password.
+/// creating or opening a keystore. It supports the creation of new keystores with a mnemonic
+/// recovery phrase and a password for convenience, as well as logging into existing keystores with
+/// a password.
 pub struct InteractiveLoader {
     dir: PathBuf,
     pub rng: ChaChaRng,

--- a/src/loader/login.rs
+++ b/src/loader/login.rs
@@ -1,0 +1,52 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the Seahorse library.
+
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    hd::KeyTree,
+    loader::{KeystoreLoader, MnemonicPasswordLogin},
+    KeystoreError,
+};
+use reef::Ledger;
+use std::path::PathBuf;
+
+/// Log into a keystore using a given password.
+///
+/// This loader will attempt to authenticate and decrypt an existing keystore under the given
+/// password. It does not support creating a new keystore.
+pub struct LoginLoader {
+    password: String,
+    dir: PathBuf,
+}
+
+impl LoginLoader {
+    pub fn new(dir: PathBuf, password: String) -> Self {
+        Self { dir, password }
+    }
+}
+
+impl<L: Ledger> KeystoreLoader<L> for LoginLoader {
+    type Meta = MnemonicPasswordLogin;
+
+    fn location(&self) -> PathBuf {
+        self.dir.clone()
+    }
+
+    fn create(&mut self) -> Result<(Self::Meta, KeyTree), KeystoreError<L>> {
+        Err(KeystoreError::Failed {
+            msg: String::from("LoginLoader does not support creating a new wallet"),
+        })
+    }
+
+    fn load(&mut self, meta: &mut Self::Meta) -> Result<KeyTree, KeystoreError<L>> {
+        let mnemonic = meta
+            .decrypt_mnemonic(self.password.as_bytes())
+            .ok_or_else(|| KeystoreError::Failed {
+                msg: String::from("incorrect password"),
+            })?;
+        Ok(KeyTree::from_mnemonic(&mnemonic))
+    }
+}

--- a/src/loader/login.rs
+++ b/src/loader/login.rs
@@ -37,7 +37,7 @@ impl<L: Ledger> KeystoreLoader<L> for LoginLoader {
 
     fn create(&mut self) -> Result<(Self::Meta, KeyTree), KeystoreError<L>> {
         Err(KeystoreError::Failed {
-            msg: String::from("LoginLoader does not support creating a new wallet"),
+            msg: String::from("LoginLoader does not support creating a new keystore"),
         })
     }
 

--- a/src/loader/recovery.rs
+++ b/src/loader/recovery.rs
@@ -18,11 +18,11 @@ use std::path::PathBuf;
 ///
 /// If encrypted keystore files already exist, this loader will use the given mnemonic phrase to
 /// decrypt them, change the keystore's password, and then re-encrypt it. If no files exist, the
-/// loader will create a new wallet using the given mnemonic and password. If the mnemonic used is
-/// in fact the same as the mnemonic used to create a wallet which has been lost, then the caller
+/// loader will create a new keystore using the given mnemonic and password. If the mnemonic used is
+/// in fact the same as the mnemonic used to create a keystore which has been lost, then the caller
 /// can recover their assets using [generate_user_key](crate::Keystore::generate_user_key) with
 /// `scan_from` set to `Some(EventIndex::default())`. This will result in regenerating the same keys
-/// that belonged to the old wallet and scanning the ledger for records belonging to those keys.
+/// that belonged to the old keystore and scanning the ledger for records belonging to those keys.
 ///
 /// Note that in the second case, recovery without encrypted keystore files, the loader cannot check
 /// if the given mnemonic is correct. The caller will only discover that they have used the wrong

--- a/src/loader/recovery.rs
+++ b/src/loader/recovery.rs
@@ -1,0 +1,76 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the Seahorse library.
+
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    hd::{KeyTree, Mnemonic},
+    loader::{KeystoreLoader, MnemonicPasswordLogin},
+    KeystoreError,
+};
+use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
+use reef::Ledger;
+use std::path::PathBuf;
+
+/// Recover a keystore from a mnemonic phrase.
+///
+/// If encrypted keystore files already exist, this loader will use the given mnemonic phrase to
+/// decrypt them, change the keystore's password, and then re-encrypt it. If no files exist, the
+/// loader will create a new wallet using the given mnemonic and password. If the mnemonic used is
+/// in fact the same as the mnemonic used to create a wallet which has been lost, then the caller
+/// can recover their assets using [generate_user_key](crate::Keystore::generate_user_key) with
+/// `scan_from` set to `Some(EventIndex::default())`. This will result in regenerating the same keys
+/// that belonged to the old wallet and scanning the ledger for records belonging to those keys.
+///
+/// Note that in the second case, recovery without encrypted keystore files, the loader cannot check
+/// if the given mnemonic is correct. The caller will only discover that they have used the wrong
+/// mnemonic when they fail to recover their balance of assets. When the keystore files are present,
+/// however, the loader will return an error if the mnemonic is not the one which was used to create
+/// the existing files.
+pub struct RecoveryLoader {
+    mnemonic: Mnemonic,
+    new_password: String,
+    dir: PathBuf,
+    rng: ChaChaRng,
+}
+
+impl RecoveryLoader {
+    pub fn new(
+        rng: &mut ChaChaRng,
+        dir: PathBuf,
+        mnemonic: Mnemonic,
+        new_password: String,
+    ) -> Self {
+        Self {
+            dir,
+            mnemonic,
+            new_password,
+            rng: ChaChaRng::from_rng(rng).unwrap(),
+        }
+    }
+}
+
+impl<L: Ledger> KeystoreLoader<L> for RecoveryLoader {
+    type Meta = MnemonicPasswordLogin;
+
+    fn location(&self) -> PathBuf {
+        self.dir.clone()
+    }
+
+    fn create(&mut self) -> Result<(Self::Meta, KeyTree), KeystoreError<L>> {
+        let meta = MnemonicPasswordLogin::new(
+            &mut self.rng,
+            &self.mnemonic,
+            self.new_password.as_bytes(),
+        )?;
+        let key = KeyTree::from_mnemonic(&self.mnemonic);
+        Ok((meta, key))
+    }
+
+    fn load(&mut self, meta: &mut Self::Meta) -> Result<KeyTree, KeystoreError<L>> {
+        meta.set_password(&mut self.rng, &self.mnemonic, self.new_password.as_bytes())?;
+        Ok(KeyTree::from_mnemonic(&self.mnemonic))
+    }
+}

--- a/src/loader/tests.rs
+++ b/src/loader/tests.rs
@@ -1,0 +1,150 @@
+use super::*;
+use rand::distributions::{Alphanumeric, DistString};
+use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
+use reef::cap;
+use tempdir::TempDir;
+
+#[test]
+fn test_create_loader() {
+    let dir = TempDir::new("create-loader").unwrap();
+    let mut rng = ChaChaRng::from_seed([0; 32]);
+    let mnemonic = KeyTree::random(&mut rng).1;
+    let password = Alphanumeric.sample_string(&mut rng, 16);
+
+    // First create some keystore metadata.
+    let mut loader = CreateLoader::new(
+        &mut rng,
+        dir.path().to_owned(),
+        mnemonic.clone(),
+        password.clone(),
+    );
+    assert_eq!(
+        KeystoreLoader::<cap::Ledger>::location(&loader),
+        dir.path().to_owned()
+    );
+    let (meta, key) = KeystoreLoader::<cap::Ledger>::create(&mut loader).unwrap();
+    assert_eq!(
+        meta.decrypt_mnemonic(password.as_bytes()),
+        Some(mnemonic.clone())
+    );
+    assert!(meta.check_password(password.as_bytes()));
+    assert!(meta.check_mnemonic(&mnemonic));
+
+    // Load it back with a different loader. Make sure we get the same result, and the metadata
+    // isn't changed.
+    let mut loaded = meta.clone();
+    let mut loader = CreateLoader::new(
+        &mut rng,
+        dir.path().to_owned(),
+        mnemonic.clone(),
+        password.clone(),
+    );
+    assert_eq!(
+        key,
+        KeystoreLoader::<cap::Ledger>::load(&mut loader, &mut loaded).unwrap()
+    );
+    assert_eq!(meta, loaded);
+
+    // Check that an exclusive loader fails with existing metadata.
+    let mut loader = CreateLoader::exclusive(
+        &mut rng,
+        dir.path().to_owned(),
+        mnemonic.clone(),
+        password.clone(),
+    );
+    KeystoreLoader::<cap::Ledger>::load(&mut loader, &mut loaded).unwrap_err();
+    assert_eq!(loaded, meta);
+
+    // Check that we fail to open an existing keystore with the wrong password.
+    let password = Alphanumeric.sample_string(&mut rng, 16);
+    let mut loader = CreateLoader::new(
+        &mut rng,
+        dir.path().to_owned(),
+        mnemonic.clone(),
+        password.clone(),
+    );
+    KeystoreLoader::<cap::Ledger>::load(&mut loader, &mut loaded).unwrap_err();
+    assert_eq!(loaded, meta);
+}
+
+#[test]
+fn test_login_loader() {
+    let dir = TempDir::new("login-loader").unwrap();
+    let mut rng = ChaChaRng::from_seed([0; 32]);
+    let mnemonic = KeyTree::random(&mut rng).1;
+    let password = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
+
+    // First create some keystore metadata.
+    let meta = MnemonicPasswordLogin::new::<cap::Ledger>(&mut rng, &mnemonic, password.as_bytes())
+        .unwrap();
+
+    // Check that we can correctly load a key tree from this metadata using only a password.
+    let mut loader = LoginLoader::new(dir.path().to_owned(), password.clone());
+    let mut loaded = meta.clone();
+    let key = KeystoreLoader::<cap::Ledger>::load(&mut loader, &mut loaded).unwrap();
+    assert_eq!(loaded, meta);
+    assert_eq!(key, KeyTree::from_mnemonic(&mnemonic));
+
+    // Check that loading fails with the incorrect password.
+    let password = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
+    let mut loader = LoginLoader::new(dir.path().to_owned(), password.clone());
+    KeystoreLoader::<cap::Ledger>::load(&mut loader, &mut loaded).unwrap_err();
+    assert_eq!(loaded, meta);
+}
+
+#[test]
+fn test_recovery_loader() {
+    let dir = TempDir::new("recovery-loader").unwrap();
+    let mut rng = ChaChaRng::from_seed([0; 32]);
+    let mnemonic = KeyTree::random(&mut rng).1;
+    let password = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
+
+    // If no keystore metadata exists, the loader creates a new keystore with the given mnemonic and
+    // password.
+    let mut loader = RecoveryLoader::new(
+        &mut rng,
+        dir.path().to_owned(),
+        mnemonic.clone(),
+        password.clone(),
+    );
+    assert_eq!(
+        KeystoreLoader::<cap::Ledger>::location(&loader),
+        dir.path().to_owned()
+    );
+    let (mut meta, key) = KeystoreLoader::<cap::Ledger>::create(&mut loader).unwrap();
+    assert_eq!(
+        meta.decrypt_mnemonic(password.as_bytes()),
+        Some(mnemonic.clone())
+    );
+    assert!(meta.check_password(password.as_bytes()));
+    assert!(meta.check_mnemonic(&mnemonic));
+
+    // If keystore files exist, we can load them back and change the password.
+    let password = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
+    let mut loader = RecoveryLoader::new(
+        &mut rng,
+        dir.path().to_owned(),
+        mnemonic.clone(),
+        password.clone(),
+    );
+    assert_eq!(
+        key,
+        KeystoreLoader::<cap::Ledger>::load(&mut loader, &mut meta).unwrap()
+    );
+    assert_eq!(
+        meta.decrypt_mnemonic(password.as_bytes()),
+        Some(mnemonic.clone())
+    );
+    assert!(meta.check_password(password.as_bytes()));
+    assert!(meta.check_mnemonic(&mnemonic));
+
+    // Loading fails if we use the wrong mnemonic.
+    let mnemonic = KeyTree::random(&mut rng).1;
+    let mut loader = RecoveryLoader::new(
+        &mut rng,
+        dir.path().to_owned(),
+        mnemonic.clone(),
+        password.clone(),
+    );
+    KeystoreLoader::<cap::Ledger>::load(&mut loader, &mut meta).unwrap_err();
+}

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -129,7 +129,7 @@ struct EncryptingResourceAdapter<T> {
 impl<T> EncryptingResourceAdapter<T> {
     fn new(key: KeyTree) -> Self {
         Self {
-            cipher: Cipher::new(key, ChaChaRng::from_entropy()),
+            cipher: Cipher::new(key, Some(ChaChaRng::from_entropy())),
             _phantom: Default::default(),
         }
     }

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -128,7 +128,7 @@ struct EncryptingResourceAdapter<T> {
 impl<T> EncryptingResourceAdapter<T> {
     fn new(key: KeyTree) -> Self {
         Self {
-            cipher: Cipher::new(key, Some(ChaChaRng::from_entropy())),
+            cipher: Cipher::new(key, ChaChaRng::from_entropy()),
             _phantom: Default::default(),
         }
     }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -22,7 +22,7 @@ use zeroize::{Zeroize, Zeroizing};
 // the compiler leaving unreachable, implicit copies of the secret scattered around memory.
 //
 // This is especially useful when S is zeroizing on drop.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 struct Pinned<S> {
     secret: S,
     _pin: PhantomPinned,
@@ -97,7 +97,7 @@ secret_default_arrays!(
 );
 
 /// A wrapper around a secret which cannot be copied.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Secret<S: Zeroize>(Pin<Box<Pinned<Zeroizing<S>>>>);
 
 impl<S: Zeroize + SecretDefault> Secret<S> {


### PR DESCRIPTION
Low priority on this review, it's not urgent, just something I've been wanting to do for a while.

The behavior of loading and creating keystores is a customization
point, with the KeystoreLoader trait defining the interface. This
is really nice, because it allows us to have different loaders with
different kinds of behavior. For example, we might have one loader
which only opens existing keystores, another which only creates new
ones, and another which knows how to recover a keystore from a
mnemonic phrase.

Unfortunately, over time we found ourselves with a single monolithic
loader, which was a tangle of different responsibilities. It included
an internal abstraction to handle both interactive input and preprogrammed
behavior with various combinations of a given mnemonic phrase and a
given password. Behavior was customized by setting some parameters to
None and others to Some, and non-interactive loading was awkwardly
achieved by scripting the interactive flow.

This change corrects the state of the loader by providing a handful
of non-interactive implementations, each of which accomplishes a
single task, alongside a single interactive loader that only does
interactive loading, and nothing else.

In addition, this improves the documentation and the public interface
of the loader. For example, MnemonicPasswordLogin (formerly known as
LoaderMetadata) now includes a public interface for inspecting the
metadata. There are functions to authenticate a mnemonic phrase or
password, and an interface for decrypting the mnemonic phrase given
the keystore's password.

Closes #75