### PR TITLE
Include hash in transaction receive history

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -51,7 +51,7 @@ pub enum LedgerEvent<L: Ledger> {
     /// included in `transaction`.
     Memos {
         outputs: Vec<(ReceiverMemo, RecordCommitment, u64, MerklePath)>,
-        transaction: Option<(u64, u64, TransactionKind<L>)>,
+        transaction: Option<(u64, u64, TransactionHash<L>, TransactionKind<L>)>,
     },
 }
 

--- a/src/key_scan.rs
+++ b/src/key_scan.rs
@@ -265,7 +265,7 @@ impl<L: Ledger> BackgroundKeyScan<L> {
                         if !received_records.is_empty() {
                             self.history.push(receive_history_entry(
                                 txn.kind(),
-                                Some(txn.hash()),
+                                txn.hash(),
                                 &received_records,
                             ));
                         }
@@ -314,10 +314,10 @@ impl<L: Ledger> BackgroundKeyScan<L> {
 
                 if !records.is_empty() {
                     // Add a history entry for the received transaction.
-                    if let Some((_, _, txn_kind)) = transaction {
+                    if let Some((_, _, hash, txn_kind)) = transaction {
                         self.history.push(receive_history_entry(
                             txn_kind,
-                            None,
+                            hash,
                             &records.into_iter().map(|(ro, _, _)| ro).collect::<Vec<_>>(),
                         ));
                     }
@@ -400,7 +400,7 @@ impl<L: Ledger> BackgroundKeyScan<L> {
 
 pub fn receive_history_entry<L: Ledger>(
     kind: TransactionKind<L>,
-    hash: Option<TransactionHash<L>>,
+    hash: TransactionHash<L>,
     records: &[RecordOpening],
 ) -> TransactionHistoryEntry<L> {
     // The last record is guaranteed not to be the fee change record. It contains useful
@@ -421,7 +421,7 @@ pub fn receive_history_entry<L: Ledger>(
         time: Local::now(),
         asset: txn_asset,
         kind,
-        hash,
+        hash: Some(hash),
         // When we receive transactions, we can't tell from the protocol who sent it to us.
         senders: Vec::new(),
         receivers: records

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -974,7 +974,7 @@ impl<'a, L: 'static + Ledger> KeystoreState<'a, L> {
         session: &mut KeystoreSession<'a, L, impl KeystoreBackend<'a, L>>,
         key_pair: &UserKeyPair,
         memos: &[(ReceiverMemo, RecordCommitment, u64, MerklePath)],
-        transaction: Option<(u64, u64, TransactionKind<L>)>,
+        transaction: Option<(u64, u64, TransactionHash<L>, TransactionKind<L>)>,
         add_to_history: bool,
     ) -> Vec<(RecordOpening, u64, MerklePath)> {
         let mut records = Vec::new();
@@ -989,13 +989,13 @@ impl<'a, L: 'static + Ledger> KeystoreState<'a, L> {
         }
 
         if add_to_history && !records.is_empty() {
-            if let Some((block_id, txn_id, kind)) = transaction {
+            if let Some((block_id, txn_id, hash, kind)) = transaction {
                 self.add_receive_history(
                     session,
                     block_id,
                     txn_id,
                     kind,
-                    None,
+                    hash,
                     &records
                         .iter()
                         .map(|(ro, _, _)| ro.clone())
@@ -1068,7 +1068,7 @@ impl<'a, L: 'static + Ledger> KeystoreState<'a, L> {
                 block_id,
                 txn_id,
                 txn.kind(),
-                Some(txn.hash()),
+                txn.hash(),
                 &my_records,
             )
             .await;
@@ -1083,7 +1083,7 @@ impl<'a, L: 'static + Ledger> KeystoreState<'a, L> {
         block_id: u64,
         txn_id: u64,
         kind: TransactionKind<L>,
-        txn_hash: Option<TransactionHash<L>>,
+        txn_hash: TransactionHash<L>,
         records: &[RecordOpening],
     ) {
         let history = receive_history_entry(kind, txn_hash, records);

--- a/src/testing/mocks.rs
+++ b/src/testing/mocks.rs
@@ -233,6 +233,7 @@ impl<'a, const H: u8> super::MockNetwork<'a, cap::LedgerWithHeight<H>>
     ) -> Result<(), KeystoreError<cap::LedgerWithHeight<H>>> {
         let (block, block_uids) = &self.committed_blocks[block_id as usize];
         let txn = &block[txn_id as usize];
+        let hash = txn.hash();
         let kind = txn.kind();
         let comms = txn.output_commitments();
         let uids = block_uids[txn_id as usize].clone();
@@ -253,7 +254,7 @@ impl<'a, const H: u8> super::MockNetwork<'a, cap::LedgerWithHeight<H>>
             .collect::<Vec<_>>();
         self.generate_event(LedgerEvent::<cap::LedgerWithHeight<H>>::Memos {
             outputs: izip!(memos, comms, uids, merkle_paths).collect(),
-            transaction: Some((block_id, txn_id, kind)),
+            transaction: Some((block_id, txn_id, hash, kind)),
         });
 
         Ok(())


### PR DESCRIPTION
This is a clean cherry-pick from release-0.2