### PR TITLE
Expose metadata from persistent storage

### DIFF
--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -318,6 +318,10 @@ impl<'a, L: Ledger, Meta: Send + Serialize + DeserializeOwned> AtomicWalletStora
     pub fn key_stream(&self) -> KeyTree {
         self.wallet_key_tree.clone()
     }
+
+    pub fn meta(&self) -> &Meta {
+        &self.meta
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
This is generally useful for inspecting metadata about a wallet (for example, version number, or mnemonic phrase). In particular, CAPE will use this by storing the contract address for which the wallet was created in the metadata, and then using the stored address to check if the wallet is up to date with the latest contract provided by the EQS.