### PR TITLE
Port improvements from release-0.2

### DIFF
--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -321,6 +321,10 @@ impl<'a, L: Ledger, Meta: Send + Serialize + DeserializeOwned> AtomicKeystoreSto
     pub fn key_stream(&self) -> KeyTree {
         self.keystore_key_tree.clone()
     }
+
+    pub fn meta(&self) -> &Meta {
+        &self.meta
+    }
 }
 
 impl<'a, L: Ledger, Meta: Send + Serialize + DeserializeOwned> AtomicKeystoreStorage<'a, L, Meta> {

--- a/src/testing/tests.rs
+++ b/src/testing/tests.rs
@@ -2669,6 +2669,22 @@ pub mod generic_keystore_tests {
             )
             .await
             .unwrap();
+        assert!(
+            keystores[0]
+                .0
+                .viewing_account(&viewing_key)
+                .await
+                .unwrap()
+                .used
+        );
+        assert!(
+            !keystores[0]
+                .0
+                .freezing_account(&freezing_key)
+                .await
+                .unwrap()
+                .used
+        );
         let freezable_asset = keystores[0]
             .0
             .define_asset(
@@ -2682,6 +2698,22 @@ pub mod generic_keystore_tests {
             )
             .await
             .unwrap();
+        assert!(
+            keystores[0]
+                .0
+                .viewing_account(&viewing_key)
+                .await
+                .unwrap()
+                .used
+        );
+        assert!(
+            keystores[0]
+                .0
+                .freezing_account(&freezing_key)
+                .await
+                .unwrap()
+                .used
+        );
         // Check that the new assets appear in the proper accounts.
         assert_eq!(
             keystores[0]
@@ -2714,8 +2746,8 @@ pub mod generic_keystore_tests {
             vec![freezable_asset.clone()]
         );
 
-        // Mint some of each asset for the other keystore (`keystores[1]`). Check that both accounts are
-        // marked used and the freezable record is added to both accounts.
+        // Mint some of each asset for the other keystore (`keystores[1]`). Check that the freezable
+        // record is added to both accounts.
         let receiver = keystores[1].1[0].clone();
         let receipt = keystores[0]
             .0
@@ -2729,22 +2761,6 @@ pub mod generic_keystore_tests {
             .await
             .unwrap();
         await_transaction(&receipt, &keystores[0].0, &[&keystores[1].0]).await;
-        assert!(
-            keystores[0]
-                .0
-                .viewing_account(&viewing_key)
-                .await
-                .unwrap()
-                .used
-        );
-        assert!(
-            !keystores[0]
-                .0
-                .freezing_account(&freezing_key)
-                .await
-                .unwrap()
-                .used
-        );
         t.check_storage(&keystores).await;
 
         // Mint the freezable asset.


### PR DESCRIPTION
* Consider viewing and freezing accounts used if they are used to define an asset
* Do not require CLI implementations to use the default Loader or Metadata
* Expose metadata from persistent storage