### PR TITLE
Fix panic in key scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2668,9 +2668,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "oorandom"
@@ -3501,6 +3501,7 @@ dependencies = [
  "surf",
  "tagged-base64",
  "tempdir",
+ "tracing",
  "zeroize",
 ]
 
@@ -4191,9 +4192,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.31"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -4204,9 +4205,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4215,11 +4216,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.22"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
+checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "seahorse"
 description = "A generic cap-style cryptocurrency wallet."
 authors = ["Espresso Systems <hello@espressosys.com>"]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2018"
 license = "GPL-3.0-or-later"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ strum = "0.24"
 strum_macros = "0.20.1"
 surf = "2.3.1"
 tempdir = "0.3.7"
+tracing = "0.1.35"
 zeroize = "1.3"
 
 # local dependencies


### PR DESCRIPTION
When remembering a Merkle path during key scan, we need to make
sure to clear `leaf_to_forget` if `leaf_to_forget` is the remembered
leaf, otherwise we will just forget the path again as soon as more
commitments are appended.