### PR TITLE
Move AtomicStore to upper level and refactor storage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1780,8 +1780,7 @@ impl<
         let mut atomic_store = AtomicStore::open(atomic_loader).unwrap();
         Box::pin(async move {
             let state = if storage.exists() {
-                let state = storage.load().await?;
-                state
+                storage.load().await?
             } else {
                 let state = backend.create().await?;
                 storage.create(&state).await?;

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -20,7 +20,7 @@ use async_std::sync::Arc;
 use atomic_store::{
     error::PersistenceError,
     load_store::{BincodeLoadStore, LoadStore},
-    AppendLog, AtomicStore, AtomicStoreLoader, RollingLog,
+    AppendLog, AtomicStoreLoader, RollingLog,
 };
 use espresso_macros::ser_test;
 use jf_cap::keys::{FreezerKeyPair, UserKeyPair, ViewerKeyPair};
@@ -195,16 +195,13 @@ impl<'a, L: Ledger, Meta: Send + Serialize + DeserializeOwned + Clone + PartialE
 {
     pub fn new(
         loader: &mut impl KeystoreLoader<L, Meta = Meta>,
+        atomic_loader: &mut AtomicStoreLoader,
         file_fill_size: u64,
-    ) -> Result<(Self, AtomicStore), KeystoreError<L>> {
-        let directory = loader.location();
-        let mut atomic_loader =
-            AtomicStoreLoader::load(&directory, "keystore").context(crate::PersistenceSnafu)?;
-
+    ) -> Result<Self, KeystoreError<L>> {
         // Load the metadata first so the loader can use it to generate the encryption key needed to
         // read the rest of the data.
         let mut persisted_meta = RollingLog::load(
-            &mut atomic_loader,
+            atomic_loader,
             BincodeLoadStore::<Meta>::default(),
             "keystore_meta",
             1024,
@@ -234,53 +231,48 @@ impl<'a, L: Ledger, Meta: Send + Serialize + DeserializeOwned + Clone + PartialE
 
         let adaptor = EncryptingResourceAdapter::<()>::new(key.derive_sub_tree("enc".as_bytes()));
         let static_data = RollingLog::load(
-            &mut atomic_loader,
+            atomic_loader,
             adaptor.cast(),
             "keystore_static",
             file_fill_size,
         )
         .context(crate::PersistenceSnafu)?;
-
         let dynamic_state = RollingLog::load(
-            &mut atomic_loader,
+            atomic_loader,
             adaptor.cast(),
             "keystore_dyn",
             file_fill_size,
         )
         .context(crate::PersistenceSnafu)?;
         let assets = AppendLog::load(
-            &mut atomic_loader,
+            atomic_loader,
             adaptor.cast(),
             "keystore_assets",
             file_fill_size,
         )
         .context(crate::PersistenceSnafu)?;
         let txn_history = AppendLog::load(
-            &mut atomic_loader,
+            atomic_loader,
             adaptor.cast(),
             "keystore_txns",
             file_fill_size,
         )
         .context(crate::PersistenceSnafu)?;
-        let store = AtomicStore::open(atomic_loader).context(crate::PersistenceSnafu)?;
 
-        Ok((
-            Self {
-                meta,
-                persisted_meta,
-                meta_dirty,
-                static_data,
-                static_dirty: false,
-                dynamic_state,
-                dynamic_state_dirty: false,
-                assets,
-                assets_dirty: false,
-                txn_history,
-                txn_history_dirty: false,
-                keystore_key_tree: key.derive_sub_tree("keystore".as_bytes()),
-            },
-            store,
-        ))
+        Ok(Self {
+            meta,
+            persisted_meta,
+            meta_dirty,
+            static_data,
+            static_dirty: false,
+            dynamic_state,
+            dynamic_state_dirty: false,
+            assets,
+            assets_dirty: false,
+            txn_history,
+            txn_history_dirty: false,
+            keystore_key_tree: key.derive_sub_tree("keystore".as_bytes()),
+        })
     }
 }
 
@@ -288,7 +280,6 @@ impl<'a, L: Ledger, Meta: Send + Serialize + DeserializeOwned> AtomicKeystoreSto
     pub async fn create(
         mut self: &mut Self,
         w: &KeystoreState<'a, L>,
-        atomic_store: &mut AtomicStore,
     ) -> Result<(), KeystoreError<L>> {
         // Store the initial static and dynamic state, and the metadata. We do this in a closure so
         // that if any operation fails, it will exit the closure but not this function, and we can
@@ -311,7 +302,6 @@ impl<'a, L: Ledger, Meta: Send + Serialize + DeserializeOwned> AtomicKeystoreSto
         {
             Ok(()) => {
                 self.commit().await;
-                atomic_store.commit_version().unwrap();
                 Ok(())
             }
             Err(err) => {
@@ -335,14 +325,10 @@ impl<'a, L: Ledger, Meta: Send + Serialize + DeserializeOwned> AtomicKeystoreSto
         self.persisted_meta.load_latest().is_ok()
     }
 
-    pub async fn load(
-        &mut self,
-        atomic_store: &mut AtomicStore,
-    ) -> Result<KeystoreState<'a, L>, KeystoreError<L>> {
+    pub async fn load(&mut self) -> Result<KeystoreState<'a, L>, KeystoreError<L>> {
         // This function is called once, when the keystore is loaded. It is a good place to persist
         // changes to the metadata that happened during loading.
         self.commit().await;
-        atomic_store.commit_version().unwrap();
 
         let static_state = self
             .static_data
@@ -487,6 +473,7 @@ mod tests {
         testing::assert_keystore_states_eq,
         txn_builder::{PendingTransaction, TransactionInfo, TransactionUID},
     };
+    use atomic_store::AtomicStore;
     use chrono::Local;
     use commit::Commitment;
     use jf_cap::{
@@ -625,11 +612,18 @@ mod tests {
             key: KeyTree::random(&mut rng).0,
         };
         {
-            let (mut storage, mut atomic_store) =
-                AtomicKeystoreStorage::new(&mut loader, 1024).unwrap();
+            let mut atomic_loader = AtomicStoreLoader::load(
+                &KeystoreLoader::<cap::Ledger>::location(&loader),
+                "keystore",
+            )
+            .unwrap();
+            let mut storage =
+                AtomicKeystoreStorage::new(&mut loader, &mut atomic_loader, 1024).unwrap();
             assert!(!storage.exists());
-            storage.create(&state, &mut atomic_store).await.unwrap();
+            let mut atomic_store = AtomicStore::open(atomic_loader).unwrap();
+            storage.create(&state).await.unwrap();
             assert!(storage.exists());
+            atomic_store.commit_version().unwrap();
         }
 
         (state, loader, rng)
@@ -643,9 +637,17 @@ mod tests {
         // load comes only from persistent storage and not from any in-memory state of the first
         // instance.
         let loaded = {
-            let (mut storage, mut atomic_store) =
-                AtomicKeystoreStorage::new(&mut loader, 1024).unwrap();
-            storage.load(&mut atomic_store).await.unwrap()
+            let mut atomic_loader = AtomicStoreLoader::load(
+                &KeystoreLoader::<cap::Ledger>::location(&loader),
+                "keystore",
+            )
+            .unwrap();
+            let mut storage =
+                AtomicKeystoreStorage::new(&mut loader, &mut atomic_loader, 1024).unwrap();
+            let mut atomic_store = AtomicStore::open(atomic_loader).unwrap();
+            let state = storage.load().await.unwrap();
+            atomic_store.commit_version().unwrap();
+            state
         };
         assert_keystore_states_eq(&stored, &loaded);
 
@@ -681,14 +683,30 @@ mod tests {
 
         // Snapshot the modified dynamic state and then reload.
         {
-            let (mut storage, _) = AtomicKeystoreStorage::new(&mut loader, 1024).unwrap();
+            let mut atomic_loader = AtomicStoreLoader::load(
+                &KeystoreLoader::<cap::Ledger>::location(&loader),
+                "keystore",
+            )
+            .unwrap();
+            let mut storage =
+                AtomicKeystoreStorage::new(&mut loader, &mut atomic_loader, 1024).unwrap();
+            let mut atomic_store = AtomicStore::open(atomic_loader).unwrap();
             storage.store_snapshot(&stored).await.unwrap();
             storage.commit().await;
+            atomic_store.commit_version().unwrap();
         }
         let loaded = {
-            let (mut storage, mut atomic_store) =
-                AtomicKeystoreStorage::new(&mut loader, 1024).unwrap();
-            storage.load(&mut atomic_store).await.unwrap()
+            let mut atomic_loader = AtomicStoreLoader::load(
+                &KeystoreLoader::<cap::Ledger>::location(&loader),
+                "keystore",
+            )
+            .unwrap();
+            let mut storage =
+                AtomicKeystoreStorage::new(&mut loader, &mut atomic_loader, 1024).unwrap();
+            let mut atomic_store = AtomicStore::open(atomic_loader).unwrap();
+            let state = storage.load().await.unwrap();
+            atomic_store.commit_version().unwrap();
+            state
         };
         assert_keystore_states_eq(&stored, &loaded);
 
@@ -705,16 +723,31 @@ mod tests {
             Account::new(viewing_key, "viewing_account".into()),
         );
         {
-            let (mut storage, _) =
-                AtomicKeystoreStorage::<cap::Ledger, _>::new(&mut loader, 1024).unwrap();
+            let mut atomic_loader = AtomicStoreLoader::load(
+                &KeystoreLoader::<cap::Ledger>::location(&loader),
+                "keystore",
+            )
+            .unwrap();
+            let mut storage =
+                AtomicKeystoreStorage::new(&mut loader, &mut atomic_loader, 1024).unwrap();
+            let mut atomic_store = AtomicStore::open(atomic_loader).unwrap();
             storage.store_snapshot(&stored).await.unwrap();
             storage.store_asset(&asset).await.unwrap();
             storage.commit().await;
+            atomic_store.commit_version().unwrap();
         }
         let loaded = {
-            let (mut storage, mut atomic_store) =
-                AtomicKeystoreStorage::new(&mut loader, 1024).unwrap();
-            storage.load(&mut atomic_store).await.unwrap()
+            let mut atomic_loader = AtomicStoreLoader::load(
+                &KeystoreLoader::<cap::Ledger>::location(&loader),
+                "keystore",
+            )
+            .unwrap();
+            let mut storage =
+                AtomicKeystoreStorage::new(&mut loader, &mut atomic_loader, 1024).unwrap();
+            let mut atomic_store = AtomicStore::open(atomic_loader).unwrap();
+            let state = storage.load().await.unwrap();
+            atomic_store.commit_version().unwrap();
+            state
         };
         assert_keystore_states_eq(&stored, &loaded);
 
@@ -727,23 +760,36 @@ mod tests {
 
         // Make a change to one of the data structures, but revert it.
         let loaded = {
-            let (mut storage, mut atomic_store) =
-                AtomicKeystoreStorage::new(&mut loader, 1024).unwrap();
+            let mut atomic_loader = AtomicStoreLoader::load(
+                &KeystoreLoader::<cap::Ledger>::location(&loader),
+                "keystore",
+            )
+            .unwrap();
+            let mut storage =
+                AtomicKeystoreStorage::new(&mut loader, &mut atomic_loader, 1024).unwrap();
+            let mut atomic_store = AtomicStore::open(atomic_loader).unwrap();
             storage
                 .store_asset(&AssetInfo::native::<cap::Ledger>())
                 .await
                 .unwrap();
             storage.revert().await;
-            // Make sure committing after a revert does not commit the reverted changes.
-            storage.commit().await;
-            storage.load(&mut atomic_store).await.unwrap()
+            // Make sure loading after a revert does not commit the reverted changes.
+            let state = storage.load().await.unwrap();
+            atomic_store.commit_version().unwrap();
+            state
         };
         assert_keystore_states_eq(&stored, &loaded);
 
         // Change multiple data structures and revert.
         let loaded = {
-            let (mut storage, mut atomic_store) =
-                AtomicKeystoreStorage::new(&mut loader, 1024).unwrap();
+            let mut atomic_loader = AtomicStoreLoader::load(
+                &KeystoreLoader::<cap::Ledger>::location(&loader),
+                "keystore",
+            )
+            .unwrap();
+            let mut storage =
+                AtomicKeystoreStorage::new(&mut loader, &mut atomic_loader, 1024).unwrap();
+            let mut atomic_store = AtomicStore::open(atomic_loader).unwrap();
 
             let user_key = UserKeyPair::generate(&mut rng);
             let ro = random_ro(&mut rng, &user_key);
@@ -783,9 +829,10 @@ mod tests {
                 .unwrap();
             storage.revert().await;
 
-            // Commit after revert should be a no-op.
-            storage.commit().await;
-            storage.load(&mut atomic_store).await.unwrap()
+            // Loading after revert should be a no-op.
+            let state = storage.load().await.unwrap();
+            atomic_store.commit_version().unwrap();
+            state
         };
         assert_keystore_states_eq(&stored, &loaded);
 

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -525,10 +525,11 @@ pub trait SystemUnderTest<'a>: Default + Send + Sync {
     ) {
         for (keystore, _, _) in keystores {
             let KeystoreSharedState { state, session, .. } = &mut *keystore.mutex.lock().await;
-            let mut atomic_store = &mut session.atomic_store;
+            let atomic_store = &mut session.atomic_store;
             let storage = &session.storage;
             let mut state = state.clone();
-            let mut loaded = storage.lock().await.load(&mut atomic_store).await.unwrap();
+            let mut loaded = storage.lock().await.load().await.unwrap();
+            atomic_store.commit_version().unwrap();
 
             // The persisted state should not include any temporary assets.
             state.assets = AssetLibrary::new(

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -524,10 +524,11 @@ pub trait SystemUnderTest<'a>: Default + Send + Sync {
         )],
     ) {
         for (keystore, _, _) in keystores {
-            let KeystoreSharedState { state, session, .. } = &*keystore.mutex.lock().await;
+            let KeystoreSharedState { state, session, .. } = &mut *keystore.mutex.lock().await;
+            let mut atomic_store = &mut session.atomic_store;
             let storage = &session.storage;
             let mut state = state.clone();
-            let mut loaded = storage.lock().await.load().await.unwrap();
+            let mut loaded = storage.lock().await.load(&mut atomic_store).await.unwrap();
 
             // The persisted state should not include any temporary assets.
             state.assets = AssetLibrary::new(

--- a/src/testing/tests.rs
+++ b/src/testing/tests.rs
@@ -4,7 +4,7 @@
 // This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 // This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
-// #![deny(warnings)]
+#![deny(warnings)]
 
 use super::*;
 use chrono::Duration;

--- a/src/testing/tests.rs
+++ b/src/testing/tests.rs
@@ -2483,12 +2483,13 @@ pub mod generic_keystore_tests {
         {
             let storage = &keystores[0].0.lock().await.session.storage;
             let atomic_store = &mut keystores[0].0.lock().await.session.atomic_store;
-            let loaded = storage.lock().await.load(atomic_store).await.unwrap();
+            let loaded = storage.lock().await.load().await.unwrap();
             assert!(loaded.assets.iter().all(|asset| !asset.verified));
             assert!(loaded.assets.contains(AssetCode::native()));
             assert!(loaded.assets.contains(asset1.code));
             assert!(!loaded.assets.contains(asset2.code));
             assert_eq!(loaded.assets.len(), 2);
+            atomic_store.commit_version().unwrap();
         }
 
         // Now import `asset2`, updating the existing verified asset with persistence and mint info.
@@ -2514,12 +2515,13 @@ pub mod generic_keystore_tests {
         {
             let storage = &keystores[0].0.mutex.lock().await.session.storage;
             let atomic_store = &mut keystores[0].0.lock().await.session.atomic_store;
-            let loaded = storage.lock().await.load(atomic_store).await.unwrap();
+            let loaded = storage.lock().await.load().await.unwrap();
             assert!(loaded.assets.iter().all(|asset| !asset.verified));
             assert!(loaded.assets.contains(AssetCode::native()));
             assert!(loaded.assets.contains(asset1.code));
             assert!(loaded.assets.contains(asset2.code));
             assert_eq!(loaded.assets.len(), 3);
+            atomic_store.commit_version().unwrap();
         }
 
         // Finally, check that by loading the persisted, unverified information, and combining it
@@ -2528,13 +2530,8 @@ pub mod generic_keystore_tests {
         let loaded = {
             let storage = &keystores[0].0.mutex.lock().await.session.storage;
             let atomic_store = &mut keystores[0].0.lock().await.session.atomic_store;
-            let mut assets = storage
-                .lock()
-                .await
-                .load(atomic_store)
-                .await
-                .unwrap()
-                .assets;
+            let mut assets = storage.lock().await.load().await.unwrap().assets;
+            atomic_store.commit_version().unwrap();
             for asset in &imported {
                 assets.insert(asset.clone());
             }

--- a/src/testing/tests.rs
+++ b/src/testing/tests.rs
@@ -2482,7 +2482,8 @@ pub mod generic_keystore_tests {
         // verified.
         {
             let storage = &keystores[0].0.lock().await.session.storage;
-            let loaded = storage.lock().await.load().await.unwrap();
+            let atomic_store = &mut keystores[0].0.lock().await.session.atomic_store;
+            let loaded = storage.lock().await.load(atomic_store).await.unwrap();
             assert!(loaded.assets.iter().all(|asset| !asset.verified));
             assert!(loaded.assets.contains(AssetCode::native()));
             assert!(loaded.assets.contains(asset1.code));
@@ -2512,7 +2513,8 @@ pub mod generic_keystore_tests {
         // Check that `asset2` is now persisted, but still no assets in storage are verified.
         {
             let storage = &keystores[0].0.mutex.lock().await.session.storage;
-            let loaded = storage.lock().await.load().await.unwrap();
+            let atomic_store = &mut keystores[0].0.lock().await.session.atomic_store;
+            let loaded = storage.lock().await.load(atomic_store).await.unwrap();
             assert!(loaded.assets.iter().all(|asset| !asset.verified));
             assert!(loaded.assets.contains(AssetCode::native()));
             assert!(loaded.assets.contains(asset1.code));
@@ -2525,7 +2527,14 @@ pub mod generic_keystore_tests {
         // generated in a different order).
         let loaded = {
             let storage = &keystores[0].0.mutex.lock().await.session.storage;
-            let mut assets = storage.lock().await.load().await.unwrap().assets;
+            let atomic_store = &mut keystores[0].0.lock().await.session.atomic_store;
+            let mut assets = storage
+                .lock()
+                .await
+                .load(atomic_store)
+                .await
+                .unwrap()
+                .assets;
             for asset in &imported {
                 assets.insert(asset.clone());
             }

--- a/src/testing/tests.rs
+++ b/src/testing/tests.rs
@@ -4,7 +4,7 @@
 // This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 // This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
-#![deny(warnings)]
+// #![deny(warnings)]
 
 use super::*;
 use chrono::Duration;
@@ -2481,8 +2481,9 @@ pub mod generic_keystore_tests {
         // Check that temporary assets are not persisted, and that persisted assets are never
         // verified.
         {
-            let storage = &keystores[0].0.lock().await.session.storage;
-            let atomic_store = &mut keystores[0].0.lock().await.session.atomic_store;
+            let session = &mut keystores[0].0.lock().await.session;
+            let storage = &session.storage;
+            let atomic_store = &mut session.atomic_store;
             let loaded = storage.lock().await.load().await.unwrap();
             assert!(loaded.assets.iter().all(|asset| !asset.verified));
             assert!(loaded.assets.contains(AssetCode::native()));
@@ -2513,8 +2514,9 @@ pub mod generic_keystore_tests {
 
         // Check that `asset2` is now persisted, but still no assets in storage are verified.
         {
-            let storage = &keystores[0].0.mutex.lock().await.session.storage;
-            let atomic_store = &mut keystores[0].0.lock().await.session.atomic_store;
+            let session = &mut keystores[0].0.lock().await.session;
+            let storage = &session.storage;
+            let atomic_store = &mut session.atomic_store;
             let loaded = storage.lock().await.load().await.unwrap();
             assert!(loaded.assets.iter().all(|asset| !asset.verified));
             assert!(loaded.assets.contains(AssetCode::native()));
@@ -2528,8 +2530,9 @@ pub mod generic_keystore_tests {
         // with the verified information, we get back the current in-memory information (which was
         // generated in a different order).
         let loaded = {
-            let storage = &keystores[0].0.mutex.lock().await.session.storage;
-            let atomic_store = &mut keystores[0].0.lock().await.session.atomic_store;
+            let session = &mut keystores[0].0.lock().await.session;
+            let storage = &session.storage;
+            let atomic_store = &mut session.atomic_store;
             let mut assets = storage.lock().await.load().await.unwrap().assets;
             atomic_store.commit_version().unwrap();
             for asset in &imported {


### PR DESCRIPTION
- Moves `AtomicStore` from `AtomicKeystoreStorage` to `KeystoreSession`.
- Commits store version in the upper level.

Closes https://github.com/EspressoSystems/seahorse/issues/203.