### PR TITLE
Move slow tests to a separate workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,10 @@ jobs:
         run: |
           cargo bench --features=testing --no-run
 
+      - name: Build Slow Tests
+        # Make sure the slow tests build, but don't run them (we have another workflow for that).
+        run: cargo test --release --features=slow-tests --no-run
+
       - name: Test
         run: |
           cargo test --workspace --release --verbose -- -Zunstable-options --report-time --test-threads 2

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -16,19 +16,12 @@ jobs:
   build:
     runs-on: [self-hosted, X64]
     container:
-      image: ghcr.io/espressosystems/nix:main
-      volumes:
-        - github_nix:/nix
+      image: ghcr.io/espressosystems/devops-rust:1.59
     steps:
       - uses: styfle/cancel-workflow-action@0.9.1
         name: Cancel Outdated Builds
         with:
           access_token: ${{ github.token }}
-
-      - uses: cachix/cachix-action@v10
-        with:
-          name: espresso-systems-private
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Potential broken submodules fix
         run: |
@@ -36,19 +29,12 @@ jobs:
       - uses: actions/checkout@v2
         name: Checkout Repository
 
-      - name: Initialize Nix Shell
-        run: nix-shell --run "echo Init"
-
-      - name: Cache cargo
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git
-            target
-          # todo: add nix key, for example:  nix-instantiate shell.nix | sha256sum  | head -c 10
-          key: cape-v5-${{ hashFiles('Cargo.lock') }}
+      - name: Configure Git
+        run: |
+          git config --global url."https://ancient123:${{ secrets.ORG_GITHUB_PAT }}@github.com".insteadOf git://github.com
+          git config --global url."https://ancient123:${{ secrets.ORG_GITHUB_PAT }}@github.com".insteadOf ssh://git@github.com
+      - uses: Swatinem/rust-cache@v1
+        name: Enable Rust Caching
 
       - name: Run Tests
         run: cargo test --release --features=slow-tests

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -1,0 +1,54 @@
+name: Slow Tests
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+  schedule:
+    - cron: "0 1 * * 1"
+  workflow_dispatch:
+
+env:
+  RUST_TEST_THREADS: 4
+
+jobs:
+  build:
+    runs-on: [self-hosted, X64]
+    container:
+      image: ghcr.io/espressosystems/nix:main
+      volumes:
+        - github_nix:/nix
+    steps:
+      - uses: styfle/cancel-workflow-action@0.9.1
+        name: Cancel Outdated Builds
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: cachix/cachix-action@v10
+        with:
+          name: espresso-systems-private
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Potential broken submodules fix
+        run: |
+          git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :
+      - uses: actions/checkout@v2
+        name: Checkout Repository
+
+      - name: Initialize Nix Shell
+        run: nix-shell --run "echo Init"
+
+      - name: Cache cargo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git
+            target
+          # todo: add nix key, for example:  nix-instantiate shell.nix | sha256sum  | head -c 10
+          key: cape-v5-${{ hashFiles('Cargo.lock') }}
+
+      - name: Run Tests
+        run: cargo test --release --features=slow-tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ rand = "0.8.5"
 reef = { git = "https://github.com/EspressoSystems/reef.git", features = ["testing"] }
 
 [features]
+slow-tests = []
 testing = ["proptest", "criterion", "reef/testing"]
 
 [[bench]]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1085,7 +1085,7 @@ async fn repl<'a, L: 'static + Ledger, C: CLI<'a, Ledger = L>>(
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "slow-tests"))]
 mod test {
     use super::*;
     use crate::{

--- a/src/sparse_merkle_tree.rs
+++ b/src/sparse_merkle_tree.rs
@@ -274,8 +274,10 @@ mod test {
     use super::*;
     use ark_std::UniformRand;
     use quickcheck::Gen;
+    #[cfg(feature = "slow-tests")]
     use quickcheck_macros::quickcheck;
     use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
+    #[cfg(feature = "slow-tests")]
     use std::collections::HashSet;
 
     #[derive(Clone, Debug)]
@@ -301,6 +303,7 @@ mod test {
         }
     }
 
+    #[cfg(feature = "slow-tests")]
     #[quickcheck]
     fn quickcheck_sparse_merkle_tree(ops: Vec<MerkleOp>) -> bool {
         // We will do the same pushes to both `sparse_tree` and `full_tree`, but only forget/

--- a/src/testing/mocks.rs
+++ b/src/testing/mocks.rs
@@ -363,7 +363,7 @@ pub type MockBackend<'a> = MockBackendWithHeight<'a, 5>;
 pub type MockNetwork<'a> = MockNetworkWithHeight<'a, 5>;
 pub type MockSystem = MockSystemWithHeight<5>;
 
-#[cfg(all(test, feature = "slow-tests"))]
+#[cfg(test)]
 mod tests {
     use super::super::generic_keystore_tests;
     instantiate_generic_keystore_tests!(super::MockSystem);

--- a/src/testing/mocks.rs
+++ b/src/testing/mocks.rs
@@ -363,7 +363,7 @@ pub type MockBackend<'a> = MockBackendWithHeight<'a, 5>;
 pub type MockNetwork<'a> = MockNetworkWithHeight<'a, 5>;
 pub type MockSystem = MockSystemWithHeight<5>;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "slow-tests"))]
 mod tests {
     use super::super::generic_keystore_tests;
     instantiate_generic_keystore_tests!(super::MockSystem);


### PR DESCRIPTION
- Adds `feature = "slow-tests"` to slow tests.
- Moves slow tests from `Build` to a different workflow.

Closes https://github.com/EspressoSystems/espresso/issues/391.