### PR TITLE
Release 0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,12 +605,11 @@ checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atomic_store"
-version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/atomicstore.git?tag=0.1.1#e116cea2de934fd315f690d07d45b3bb7a213654"
+version = "0.1.3"
+source = "git+https://github.com/EspressoSystems/atomicstore.git?tag=0.1.3#9da9998dd8d92f61c5b78a8f0676d415e6fafe92"
 dependencies = [
  "ark-serialize",
  "bincode",
- "chrono",
  "glob",
  "serde",
  "snafu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3450,7 +3450,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "seahorse"
-version = "0.2.4"
+version = "0.2.6"
 dependencies = [
  "arbitrary",
  "arbitrary-wrappers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "seahorse"
 description = "A generic cap-style cryptocurrency wallet."
 authors = ["Espresso Systems <hello@espressosys.com>"]
-version = "0.2.5"
+version = "0.2.6"
 edition = "2018"
 license = "GPL-3.0-or-later"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ tracing = "0.1.35"
 zeroize = "1.3"
 
 # local dependencies
-atomic_store = { git = "https://github.com/EspressoSystems/atomicstore.git", tag = "0.1.1" }
+atomic_store = { git = "https://github.com/EspressoSystems/atomicstore.git", tag = "0.1.3" }
 commit = { git = "https://github.com/EspressoSystems/commit.git", tag = "0.1.0" }
 key-set = { git = "https://github.com/EspressoSystems/key-set.git", tag = "0.2.3" }
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0" }


### PR DESCRIPTION
Update atomicstore to 0.1.3 so we can get atomic store log rotation in CAPE.