### PR TITLE
Implement Persistable for in-memory states

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -661,7 +661,7 @@ impl Assets {
         let mut assets = Vec::new();
         for mut asset in self.store.iter().cloned() {
             // The asset is verified if it's in the verified set.
-            if self.verified_assets.index.contains(&asset.code()) {
+            if self.verified_assets.index().contains(&asset.code()) {
                 asset.verified = true;
             }
             assets.push(asset.clone());
@@ -673,7 +673,7 @@ impl Assets {
     pub fn get<L: Ledger>(&self, code: &AssetCode) -> Result<Asset, KeystoreError<L>> {
         let mut asset = self.store.load(code)?;
         // The asset is verified if it's in the verified set.
-        if self.verified_assets.index.contains(code) {
+        if self.verified_assets.index().contains(code) {
             asset.verified = true
         }
         Ok(asset)
@@ -686,7 +686,7 @@ impl Assets {
     ) -> Result<AssetEditor<'_>, KeystoreError<L>> {
         let mut asset = self.get(code)?;
         // The asset is verified if it's in the verified set.
-        if self.verified_assets.index.contains(code) {
+        if self.verified_assets.index().contains(code) {
             asset.verified = true
         }
         Ok(AssetEditor::new(&mut self.store, asset))
@@ -715,7 +715,11 @@ impl Assets {
         mut asset: Asset,
     ) -> Result<AssetEditor<'_>, KeystoreError<L>> {
         // The asset is verified if it's in the verified set.
-        if self.verified_assets.index.contains(&asset.definition.code) {
+        if self
+            .verified_assets
+            .index()
+            .contains(&asset.definition.code)
+        {
             asset.verified = true
         }
         let store_asset = self.store.load(&asset.definition.code);

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -22,7 +22,6 @@ use jf_cap::{
 use jf_primitives::signatures::{schnorr::SchnorrSignatureScheme, SignatureScheme};
 use jf_utils::tagged_blob;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 use std::io::{BufRead, Seek};
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
@@ -641,7 +640,7 @@ pub struct Assets {
     store: AssetsStore,
 
     /// A set of asset codes loaded from verified asset libraries.
-    verified_assets: HashSet<AssetCode>,
+    verified_assets: PersistableHashSet<AssetCode>,
 }
 
 impl Assets {
@@ -653,7 +652,7 @@ impl Assets {
     pub fn new<L: Ledger>(store: AssetsStore) -> Result<Self, KeystoreError<L>> {
         Ok(Self {
             store,
-            verified_assets: HashSet::new(),
+            verified_assets: Persistable::new(),
         })
     }
 
@@ -662,7 +661,7 @@ impl Assets {
         let mut assets = Vec::new();
         for mut asset in self.store.iter().cloned() {
             // The asset is verified if it's in the verified set.
-            if self.verified_assets.contains(&asset.code()) {
+            if self.verified_assets.index.contains(&asset.code()) {
                 asset.verified = true;
             }
             assets.push(asset.clone());
@@ -674,7 +673,7 @@ impl Assets {
     pub fn get<L: Ledger>(&self, code: &AssetCode) -> Result<Asset, KeystoreError<L>> {
         let mut asset = self.store.load(code)?;
         // The asset is verified if it's in the verified set.
-        if self.verified_assets.contains(code) {
+        if self.verified_assets.index.contains(code) {
             asset.verified = true
         }
         Ok(asset)
@@ -687,7 +686,7 @@ impl Assets {
     ) -> Result<AssetEditor<'_>, KeystoreError<L>> {
         let mut asset = self.get(code)?;
         // The asset is verified if it's in the verified set.
-        if self.verified_assets.contains(code) {
+        if self.verified_assets.index.contains(code) {
             asset.verified = true
         }
         Ok(AssetEditor::new(&mut self.store, asset))
@@ -695,11 +694,13 @@ impl Assets {
 
     /// Commit the store version.
     pub fn commit<L: Ledger>(&mut self) -> Result<(), KeystoreError<L>> {
+        self.verified_assets.commit();
         Ok(self.store.commit_version()?)
     }
 
     /// Revert the store version.
     pub fn revert<L: Ledger>(&mut self) -> Result<(), KeystoreError<L>> {
+        self.verified_assets.revert();
         Ok(self.store.revert_version()?)
     }
 
@@ -714,7 +715,7 @@ impl Assets {
         mut asset: Asset,
     ) -> Result<AssetEditor<'_>, KeystoreError<L>> {
         // The asset is verified if it's in the verified set.
-        if self.verified_assets.contains(&asset.definition.code) {
+        if self.verified_assets.index.contains(&asset.definition.code) {
             asset.verified = true
         }
         let store_asset = self.store.load(&asset.definition.code);

--- a/src/key_value_store.rs
+++ b/src/key_value_store.rs
@@ -7,14 +7,14 @@
 
 //! The key-value store.
 //!
-//! This module defines [KeyValueStore], which provides interfaces to keystore resources (e.g.,
-//! the assets resource) to create, read, update, and delete data.
+//! This module defines [KeyValueStore] and [Persistable], which provide interfaces to keystore
+//! resources (e.g., assets and transactions) to create, read, update, and delete data.
 
 use crate::{EncryptingResourceAdapter, KeystoreError, Ledger};
 use atomic_store::AppendLog;
 use serde::{de::DeserializeOwned, Serialize};
 use snafu::Snafu;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::Hash;
 
 /// Errors happening during key-value store operations.
@@ -111,5 +111,150 @@ impl<
         self.store.store_resource(&(key.clone(), None))?;
         self.revert_version()?;
         value
+    }
+}
+
+/// Changes for in-memory state.
+pub enum IndexChange<C: Eq> {
+    Add(C),
+    Remove(C),
+}
+
+/// An interface for persisting in-memory state.
+pub trait Persist<C> {
+    /// Construct a persistable state.
+    fn new() -> Self;
+    /// Insert data to the index.
+    fn insert(&mut self, change: C);
+    /// Remove data from the index.
+    fn remove(&mut self, change: C);
+    /// Revert the uncommitted changes.
+    fn revert(&mut self);
+}
+
+/// A persistable in-memory state.
+pub struct Persistable<I, C: Eq> {
+    /// In-memory index, including both committed and uncommitted changes.
+    pub index: I,
+    /// Changes that haven't been committed.
+    pending_changes: Vec<IndexChange<C>>,
+}
+
+impl<I, C: Eq> Persistable<I, C> {
+    /// Commit the pending changes.
+    pub fn commit(&mut self) {
+        // The index is always up-to-date, so commting only needs to clear the pending changes.
+        self.pending_changes = Vec::new();
+    }
+}
+
+pub type PersistableHashSet<K> = Persistable<HashSet<K>, K>;
+pub type PersistableHashMap<K, V> = Persistable<HashMap<K, V>, (K, V)>;
+pub type PersistableBTreeMap<K, V> = Persistable<BTreeMap<K, HashSet<V>>, (K, V)>;
+
+impl<K: Copy + Eq + Hash> Persist<K> for PersistableHashSet<K> {
+    fn new() -> Self {
+        Self {
+            index: HashSet::new(),
+            pending_changes: Vec::new(),
+        }
+    }
+
+    fn insert(&mut self, change: K) {
+        self.index.insert(change);
+        self.pending_changes.push(IndexChange::Add(change));
+    }
+
+    fn remove(&mut self, change: K) {
+        self.index.remove(&change);
+        self.pending_changes.push(IndexChange::Remove(change));
+    }
+
+    fn revert(&mut self) {
+        for change in &self.pending_changes {
+            match change {
+                IndexChange::Add(key) => {
+                    self.index.remove(key);
+                }
+                IndexChange::Remove(key) => {
+                    self.index.insert(*key);
+                }
+            }
+        }
+        self.pending_changes = Vec::new();
+    }
+}
+
+impl<K: Clone + Eq + Hash, V: Clone + Eq + Hash> Persist<(K, V)> for PersistableHashMap<K, V> {
+    fn new() -> Self {
+        Self {
+            index: HashMap::new(),
+            pending_changes: Vec::new(),
+        }
+    }
+
+    fn insert(&mut self, change: (K, V)) {
+        self.index.insert(change.0.clone(), change.1.clone());
+        self.pending_changes.push(IndexChange::Add(change));
+    }
+
+    fn remove(&mut self, change: (K, V)) {
+        self.index.remove(&change.0);
+        self.pending_changes.push(IndexChange::Remove(change));
+    }
+
+    fn revert(&mut self) {
+        for change in &self.pending_changes {
+            match change {
+                IndexChange::Add((key, _)) => {
+                    self.index.remove(key);
+                }
+                IndexChange::Remove((key, value)) => {
+                    self.index.insert(key.clone(), value.clone());
+                }
+            }
+        }
+        self.pending_changes = Vec::new();
+    }
+}
+
+impl<K: Copy + Eq + Hash + Ord, V: Clone + Eq + Hash> Persist<(K, V)>
+    for PersistableBTreeMap<K, V>
+{
+    fn new() -> Self {
+        Self {
+            index: BTreeMap::new(),
+            pending_changes: Vec::new(),
+        }
+    }
+
+    fn insert(&mut self, change: (K, V)) {
+        self.index
+            .entry(change.0)
+            .or_insert_with(HashSet::new)
+            .insert(change.1.clone());
+        self.pending_changes.push(IndexChange::Add(change));
+    }
+
+    fn remove(&mut self, change: (K, V)) {
+        self.index.remove(&change.0);
+        self.pending_changes.push(IndexChange::Remove(change));
+    }
+
+    fn revert(&mut self) {
+        for change in &self.pending_changes {
+            match change {
+                IndexChange::Add((key, _)) => {
+                    self.index.remove(key);
+                }
+                IndexChange::Remove((key, value)) => {
+                    self.index
+                        .entry(*key)
+                        .or_insert_with(HashSet::new)
+                        .insert(value.clone());
+                }
+            }
+        }
+        self.pending_changes = Vec::new();
     }
 }

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -368,13 +368,7 @@ impl<L: Ledger + Serialize + DeserializeOwned> Transactions<L> {
 
     /// Remove a transaction from the pending index when it is known to have timed out
     pub async fn remove_expired(&mut self, timeout: u64) -> Result<(), KeystoreError<L>> {
-        if let Some(expiring_uids) = self
-            .expiring_txns
-            .index()
-            .clone()
-            .get_mut(&timeout)
-            .cloned()
-        {
+        if let Some(expiring_uids) = self.expiring_txns.index().get(&timeout).cloned() {
             for uid in expiring_uids.iter() {
                 let editor = self.get_mut(uid)?;
                 editor


### PR DESCRIPTION
Implements functions for persisting in-memory states of the Assets and Transactions models.

Closes https://github.com/EspressoSystems/seahorse/issues/225. Closes https://github.com/EspressoSystems/seahorse/issues/226.