### PR TITLE
Get nullifiers from validation outputs, not directly from block.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3308,7 +3308,7 @@ dependencies = [
 [[package]]
 name = "reef"
 version = "0.3.0"
-source = "git+https://github.com/EspressoSystems/reef.git#7b45d90bcf1894a4a542e1680ccdf8cb7e6df247"
+source = "git+https://github.com/EspressoSystems/reef.git?branch=feat/sliding-nullifiers#34c68ae5b031468dd1d5d4aaf7b4742ec671a9a4"
 dependencies = [
  "arbitrary",
  "arbitrary-wrappers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ jf-primitives = { features=["std"], git = "https://github.com/EspressoSystems/je
 jf-utils = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.1" }
 arbitrary-wrappers = { git = "https://github.com/EspressoSystems/arbitrary-wrappers.git"}
 net = { git = "https://github.com/EspressoSystems/net.git" }
-reef = {  git = "https://github.com/EspressoSystems/reef.git" }
+reef = {  git = "https://github.com/EspressoSystems/reef.git", branch = "feat/sliding-nullifiers" }
 tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", tag = "0.2.0" }
 
 [dev-dependencies]
@@ -66,7 +66,7 @@ proptest = "0.8.7"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
 rand = "0.8.5"
-reef = { git = "https://github.com/EspressoSystems/reef.git", features = ["testing"] }
+reef = { git = "https://github.com/EspressoSystems/reef.git", features = ["testing"], branch = "feat/sliding-nullifiers" }
 
 [features]
 slow-tests = []

--- a/src/testing/mocks.rs
+++ b/src/testing/mocks.rs
@@ -102,7 +102,7 @@ impl<'a, const H: u8> super::MockNetwork<'a, cap::LedgerWithHeight<H>>
 
     fn submit(&mut self, block: cap::Block) -> Result<(), KeystoreError<cap::LedgerWithHeight<H>>> {
         match self.validator.validate_and_apply(block.clone()) {
-            Ok(mut uids) => {
+            Ok((mut uids, _)) => {
                 // Add nullifiers
                 for txn in &block {
                     for nullifier in txn.input_nullifiers() {


### PR DESCRIPTION
This allows validation to update out-of-date nullifier proofs, and
the wallet to automatically work with the updated proofs. This enables
a new feature in Espresso validation.

Depends on EspressoSystems/reef#50