### PR TITLE
Add pubkey not found error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,9 @@ pub enum WalletError<L: Ledger> {
     InvalidAuditorKey {
         key: AuditorPubKey,
     },
+    PubkeyNotFound {
+        address: UserAddress,
+    },
 }
 
 impl<L: Ledger> From<crate::txn_builder::TransactionError> for WalletError<L> {


### PR DESCRIPTION
In order to return `PubkeyNotFound` when `get_public_key` receives a "not found" error from the address book.