### PR TITLE
Fixes for benchmarks and related bugs

### DIFF
--- a/src/key_value_store.rs
+++ b/src/key_value_store.rs
@@ -96,7 +96,6 @@ impl<
         self.index.insert(key.clone(), value.clone());
         self.store
             .store_resource(&(key.clone(), Some(value.clone())))?;
-        self.commit_version()?;
         Ok(())
     }
 
@@ -109,7 +108,6 @@ impl<
             .remove(key)
             .ok_or(KeyValueStoreError::KeyNotFound);
         self.store.store_resource(&(key.clone(), None))?;
-        self.revert_version()?;
         value
     }
 }


### PR DESCRIPTION
* When creating wallets from a snapshotted state for benchmarking,
  ensure the snapshotted state has no keys in it. Each benchmark
  needs to carefully control which keys are in the wallet, so that
  it can accurately measure viewer, receiver, and passive listener
  wallets.
* Ensure wallets are dropped before the temp dirs containing their
  storage. There are two ways to do this:
  - When a (Keystore, ..., TempDir) tuple is dropped, the elements
    are dropped in order, which is correct
  - When a (Keystore, ..., TempDir) tuple is unpacked, as in
    ```
    let (keystore, ..., _tmp_dir) = tuple;
    ```
    then the local variables are dropped in _reverse_ order, which
    is incorrect, so we need to explicitly `drop(keystore)` before
    exiting the scope.
* Do not call commit_version and revert_version in KeyValueStore
  (except in commit and revert). These operations need to be
  synchronized between all the resources, and so they should only
  be called in the top level transaction/synchronization logic when
  doing a commit for the entire keystore.