### PR TITLE
Remove Transactions::reload() and add `created_time` and `modified_time` to record and transaction models

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -650,7 +650,7 @@ fn init_commands<'a, C: CLI<'a>>() -> Vec<Command<'a, C>> {
                             cli_write!(
                                 io,
                                 "{} {} {} {} {:?} ",
-                                txn.time(),
+                                txn.created_time(),
                                 status,
                                 asset,
                                 txn.kind(),

--- a/src/key_value_store.rs
+++ b/src/key_value_store.rs
@@ -222,8 +222,8 @@ impl<K: Clone + Eq + Hash, V: Clone> Persist<(K, V)> for PersistableHashMap<K, V
     }
 
     fn remove(&mut self, change: (K, V)) {
-        if self.index.remove(&change.0).is_some() {
-            self.pending_changes.push(IndexChange::Remove(change));
+        if let Some(removal) = self.index.remove_entry(&change.0) {
+            self.pending_changes.push(IndexChange::Remove(removal));
         }
     }
 

--- a/src/key_value_store.rs
+++ b/src/key_value_store.rs
@@ -124,6 +124,8 @@ impl<
 pub enum IndexChange<C> {
     Add(C),
     Remove(C),
+    // Takes the previous K,V pair and the updated value
+    Update(C, C),
 }
 
 /// An interface for persisting in-memory state.
@@ -173,13 +175,15 @@ impl<K: Copy + Eq + Hash> Persist<K> for PersistableHashSet<K> {
     }
 
     fn insert(&mut self, change: K) {
-        self.index.insert(change);
-        self.pending_changes.push(IndexChange::Add(change));
+        if self.index.insert(change) {
+            self.pending_changes.push(IndexChange::Add(change));
+        }
     }
 
     fn remove(&mut self, change: K) {
-        self.index.remove(&change);
-        self.pending_changes.push(IndexChange::Remove(change));
+        if self.index.remove(&change) {
+            self.pending_changes.push(IndexChange::Remove(change));
+        }
     }
 
     fn revert(&mut self) {
@@ -190,6 +194,9 @@ impl<K: Copy + Eq + Hash> Persist<K> for PersistableHashSet<K> {
                 }
                 IndexChange::Remove(key) => {
                     self.index.insert(*key);
+                }
+                IndexChange::Update(..) => {
+                    panic!("Unreachable");
                 }
             }
         }
@@ -206,8 +213,12 @@ impl<K: Clone + Eq + Hash, V: Clone> Persist<(K, V)> for PersistableHashMap<K, V
     }
 
     fn insert(&mut self, change: (K, V)) {
-        self.index.insert(change.0.clone(), change.1.clone());
-        self.pending_changes.push(IndexChange::Add(change));
+        if let Some(old) = self.index.insert(change.0.clone(), change.1.clone()) {
+            self.pending_changes
+                .push(IndexChange::Update(change.clone(), (change.0.clone(), old)))
+        } else {
+            self.pending_changes.push(IndexChange::Add(change));
+        }
     }
 
     fn remove(&mut self, change: (K, V)) {
@@ -223,6 +234,9 @@ impl<K: Clone + Eq + Hash, V: Clone> Persist<(K, V)> for PersistableHashMap<K, V
                 }
                 IndexChange::Remove((key, value)) => {
                     self.index.insert(key.clone(), value.clone());
+                }
+                IndexChange::Update((_, _), (old_key, old_val)) => {
+                    self.index.insert(old_key.clone(), old_val.clone());
                 }
             }
         }
@@ -241,11 +255,14 @@ impl<K: Copy + Eq + Hash + Ord, V: Clone + Eq + Hash> Persist<(K, V)>
     }
 
     fn insert(&mut self, change: (K, V)) {
-        self.index
+        if self
+            .index
             .entry(change.0)
             .or_insert_with(HashSet::new)
-            .insert(change.1.clone());
-        self.pending_changes.push(IndexChange::Add(change));
+            .insert(change.1.clone())
+        {
+            self.pending_changes.push(IndexChange::Add(change));
+        }
     }
 
     fn remove(&mut self, change: (K, V)) {
@@ -273,6 +290,7 @@ impl<K: Copy + Eq + Hash + Ord, V: Clone + Eq + Hash> Persist<(K, V)>
                         .or_insert_with(HashSet::new)
                         .insert(value.clone());
                 }
+                IndexChange::Update(..) => {}
             }
         }
         self.pending_changes = Vec::new();
@@ -299,11 +317,13 @@ impl<K: Clone + Eq + Hash, V: Clone + Eq + Hash + Ord> Persist<(K, V)>
 
     fn remove(&mut self, change: (K, V)) {
         let values = self.index.entry(change.0.clone()).or_default();
-        values.remove(&change.1);
+        let removed = values.remove(&change.1);
         if values.is_empty() {
             self.index.remove(&change.0);
         }
-        self.pending_changes.push(IndexChange::Remove(change));
+        if removed {
+            self.pending_changes.push(IndexChange::Remove(change));
+        }
     }
 
     fn revert(&mut self) {
@@ -322,6 +342,7 @@ impl<K: Clone + Eq + Hash, V: Clone + Eq + Hash + Ord> Persist<(K, V)>
                         .or_insert_with(BTreeSet::new)
                         .insert(value.clone());
                 }
+                IndexChange::Update(..) => {}
             }
         }
         self.pending_changes = Vec::new();

--- a/src/key_value_store.rs
+++ b/src/key_value_store.rs
@@ -215,7 +215,7 @@ impl<K: Clone + Eq + Hash, V: Clone> Persist<(K, V)> for PersistableHashMap<K, V
     fn insert(&mut self, change: (K, V)) {
         if let Some(old) = self.index.insert(change.0.clone(), change.1.clone()) {
             self.pending_changes
-                .push(IndexChange::Update((change.0.clone(), old)))
+                .push(IndexChange::Update((change.0, old)))
         } else {
             self.pending_changes.push(IndexChange::Add(change));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1956,7 +1956,7 @@ impl<
         Box::pin(async move {
             let KeystoreSharedState { model, .. } = &*self.read().await;
             let mut history = model.transactions.iter().collect::<Vec<_>>();
-            history.sort_by_key(|txn| *txn.time());
+            history.sort_by_key(|txn| *txn.created_time());
             Ok(history)
         })
     }

--- a/src/testing/tests.rs
+++ b/src/testing/tests.rs
@@ -24,10 +24,10 @@ impl<L: Ledger> PartialEq<Self> for TxnHistoryWithTimeTolerantEq<L> {
             Err(_) => 5,
         };
         let time_tolerance = Duration::minutes(time_tolerance_minutes);
-        let times_eq = if self.0.time() < other.0.time() {
-            other.0.time().clone() - self.0.time().clone() < time_tolerance
+        let times_eq = if self.0.created_time() < other.0.created_time() {
+            other.0.created_time().clone() - self.0.created_time().clone() < time_tolerance
         } else {
-            self.0.time().clone() - other.0.time().clone() < time_tolerance
+            self.0.created_time().clone() - other.0.created_time().clone() < time_tolerance
         };
         println!("time eq {}", times_eq);
         println!(
@@ -205,7 +205,7 @@ pub mod generic_keystore_tests {
     use tempdir::TempDir;
 
     fn same_txn_history<L: Ledger>(txn: &Transaction<L>, other: &Transaction<L>) -> bool {
-        txn.time() == other.time()
+        txn.created_time() == other.created_time()
             && txn.asset() == other.asset()
             && txn.kind() == other.kind()
             && txn.senders() == other.senders()

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -52,8 +52,6 @@ pub struct Transaction<L: Ledger> {
     signed_memos: Option<SignedMemos>,
     inputs: Vec<RecordOpening>,
     outputs: Vec<RecordOpening>,
-    /// Time when this transaction was created in the transaction builder or time when it was received
-    time: DateTime<Local>,
     /// The asset we are transacting
     asset: AssetCode,
     /// Describes the operation this transaction is performing (e.g Mint, Freeze, or Send)
@@ -95,6 +93,10 @@ pub struct Transaction<L: Ledger> {
     /// example, this is a transaction we received from someone else, and we do not hold the
     /// necessary viewing keys to inspect the change outputs of the transaction.
     asset_change: Option<RecordAmount>,
+    /// Time when this transaction was created in the transaction builder or time when it was received
+    created_time: DateTime<Local>,
+    /// The last time when the record was last modified.
+    modified_time: DateTime<Local>,
 }
 
 impl<L: Ledger> Transaction<L> {
@@ -113,9 +115,6 @@ impl<L: Ledger> Transaction<L> {
     }
     pub fn outputs(&self) -> &Vec<RecordOpening> {
         &self.outputs
-    }
-    pub fn time(&self) -> &DateTime<Local> {
-        &self.time
     }
     pub fn asset(&self) -> &AssetCode {
         &self.asset
@@ -140,6 +139,12 @@ impl<L: Ledger> Transaction<L> {
     }
     pub fn pending_uids(&self) -> &HashSet<u64> {
         &self.pending_uids
+    }
+    pub fn created_time(&self) -> &DateTime<Local> {
+        &self.created_time
+    }
+    pub fn modified_time(&self) -> DateTime<Local> {
+        self.modified_time
     }
 }
 
@@ -201,6 +206,7 @@ impl<'a, L: Ledger> TransactionEditor<'a, L> {
     /// Returns the stored transaction.
     pub fn save(&mut self) -> Result<Transaction<L>, KeystoreError<L>> {
         self.store.store(&self.transaction.uid, &self.transaction)?;
+        self.transaction.modified_time = Local::now();
         Ok(self.transaction.clone())
     }
 }
@@ -402,6 +408,7 @@ impl<L: Ledger> Transactions<L> {
         uid: TransactionUID<L>,
         params: TransactionParams<L>,
     ) -> Result<TransactionEditor<'_, L>, KeystoreError<L>> {
+        let time = Local::now();
         let txn = Transaction::<L> {
             uid,
             timeout: params.timeout,
@@ -410,13 +417,14 @@ impl<L: Ledger> Transactions<L> {
             signed_memos: params.signed_memos,
             inputs: params.inputs,
             outputs: params.outputs,
-            time: params.time,
             asset: params.asset,
             kind: params.kind,
             senders: params.senders,
             receivers: params.receivers,
             fee_change: params.fee_change,
             asset_change: params.asset_change,
+            created_time: time,
+            modified_time: time,
         };
         if let Some(timeout) = params.timeout {
             self.expiring_txns.insert((timeout, txn.uid().clone()));
@@ -457,12 +465,13 @@ pub fn create_test_txn<L: Ledger>(
         signed_memos: params.signed_memos,
         inputs: params.inputs,
         outputs: params.outputs,
-        time: params.time,
         asset: params.asset,
         kind: params.kind,
         senders: params.senders,
         receivers: params.receivers,
         fee_change: params.fee_change,
         asset_change: params.asset_change,
+        created_time: params.time,
+        modified_time: params.time,
     }
 }


### PR DESCRIPTION
The transactions model would reload the in memory indexes from storage after every update to a transaction.  Since the index was changed to the persistable type with rollback, when we rebuild the index we enqueue an add change for every K,V pair in the index.  This means if we call revert we would end up removing every item from the index.  Obviously this is not intended.  This change fixes that by explicitly adding and removing only what changed in the index.  We only completely rebuild the index during create and immediately commit it so if the first storage transaction after creation fails we don't wipe the index.

Also this adds timestamps to `Record` and `Transaction` in the same pattern as the other models