### PR TITLE
Update Reef dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3336,7 +3336,7 @@ dependencies = [
 [[package]]
 name = "reef"
 version = "0.3.0"
-source = "git+https://github.com/EspressoSystems/reef.git#7b45d90bcf1894a4a542e1680ccdf8cb7e6df247"
+source = "git+https://github.com/EspressoSystems/reef.git#2cab39fa229c98de8d72a795e0020e888b4af847"
 dependencies = [
  "arbitrary",
  "arbitrary-wrappers",
@@ -3345,6 +3345,7 @@ dependencies = [
  "funty 1.1.0",
  "itertools",
  "jf-cap",
+ "jf-primitives",
  "lazy_static",
  "rand_chacha 0.3.1",
  "serde",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -559,7 +559,10 @@ impl<'a, L: 'static + Ledger> KeystoreState<'a, L> {
                         // sparseness. If any of the consumers of this block (for example, the
                         // viewer component, or the owner of this keystore) care about a uid, they
                         // will set its `remember` flag to true.
-                        uids.into_iter().map(|uid| (uid, false)).collect::<Vec<_>>()
+                        uids.0
+                            .into_iter()
+                            .map(|uid| (uid, false))
+                            .collect::<Vec<_>>()
                     }
                     Err(val_err) => {
                         //todo !jeb.bearer handle this case more robustly. If we get here, it means

--- a/src/testing/mocks.rs
+++ b/src/testing/mocks.rs
@@ -35,7 +35,7 @@ use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 
 pub struct MockNetworkWithHeight<'a, const H: u8> {
-    validator: cap::Validator,
+    validator: cap::Validator<H>,
     nullifiers: HashSet<Nullifier>,
     records: MerkleTree,
     committed_blocks: Vec<(cap::Block, Vec<Vec<u64>>)>,
@@ -52,9 +52,10 @@ impl<'a, const H: u8> MockNetworkWithHeight<'a, H> {
         initial_grants: Vec<(RecordOpening, u64)>,
     ) -> Self {
         let mut network = Self {
-            validator: cap::Validator {
+            validator: cap::Validator::<H> {
                 now: 0,
-                num_records: initial_grants.len() as u64,
+                records_commitment: records.commitment(),
+                records_frontier: records.frontier(),
             },
             records,
             nullifiers: Default::default(),
@@ -103,7 +104,8 @@ impl<'a, const H: u8> super::MockNetwork<'a, cap::LedgerWithHeight<H>>
 
     fn submit(&mut self, block: cap::Block) -> Result<(), KeystoreError<cap::LedgerWithHeight<H>>> {
         match self.validator.validate_and_apply(block.clone()) {
-            Ok(mut uids) => {
+            Ok(validated) => {
+                let mut uids = validated.0;
                 // Add nullifiers
                 for txn in &block {
                     for nullifier in txn.input_nullifiers() {


### PR DESCRIPTION
Unblocking myself to update espresso's seahorse dependency.  This is the simplest possible change which keeps everything working as it was previously.

There is still a change needed to make use of the returned Merkle Paths from `validate_and_apply` but that should not require changes in espresso after update seahorse.