### PR TITLE
Allow backend access to block height when querying nullifiers

### DIFF
--- a/src/testing/mocks.rs
+++ b/src/testing/mocks.rs
@@ -284,10 +284,12 @@ impl<'a, const H: u8> KeystoreBackend<'a, cap::LedgerWithHeight<H>>
 
     async fn get_nullifier_proof(
         &self,
+        block_height: u64,
         _set: &mut cap::NullifierSet,
         nullifier: Nullifier,
     ) -> Result<(bool, ()), KeystoreError<cap::LedgerWithHeight<H>>> {
         let mut ledger = self.ledger.lock().await;
+        assert_eq!(block_height, ledger.network().committed_blocks.len() as u64);
         Ok((ledger.network().nullifiers.contains(&nullifier), ()))
     }
 


### PR DESCRIPTION
Espresso needs this because nullifier proofs in the metastate API are indexed by block height, not nullifier set hash. This is the first of a (longer term) move towards indexing things primarily by state number/block height in general.