### PR TITLE
Implement `KeystoreStores` and refactor `KeystoreModel`

### DIFF
--- a/src/ledger_state.rs
+++ b/src/ledger_state.rs
@@ -347,11 +347,10 @@ fn received_memos<L: Ledger>(
 }
 
 async fn try_open_memos<
-    'a,
     L: Ledger,
     Meta: Serialize + DeserializeOwned + Send + Sync + Clone + PartialEq,
 >(
-    stores: &mut KeystoreStores<'a, L, Meta>,
+    stores: &mut KeystoreStores<'_, L, Meta>,
     key_pair: &UserKeyPair,
     memos: &[(ReceiverMemo, RecordCommitment, u64, MerklePath)],
     transaction: Option<(u64, u64, TransactionHash<L>, TransactionKind<L>)>,
@@ -387,11 +386,10 @@ async fn try_open_memos<
 }
 
 async fn receive_attached_records<
-    'a,
     L: Ledger,
     Meta: Serialize + DeserializeOwned + Send + Sync + Clone + PartialEq,
 >(
-    stores: &mut KeystoreStores<'a, L, Meta>,
+    stores: &mut KeystoreStores<'_, L, Meta>,
     txn: &reef::Transaction<L>,
     uids: &mut [(u64, bool)],
     add_to_history: bool,
@@ -450,11 +448,10 @@ async fn receive_attached_records<
 }
 
 async fn add_receive_history<
-    'a,
     L: Ledger,
     Meta: Serialize + DeserializeOwned + Send + Sync + Clone + PartialEq,
 >(
-    stores: &mut KeystoreStores<'a, L, Meta>,
+    stores: &mut KeystoreStores<'_, L, Meta>,
     kind: TransactionKind<L>,
     hash: TransactionHash<L>,
     records: &[RecordOpening],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,11 +410,10 @@ pub fn verify_assets<
 /// Note that this function cannot be used to import verified assets. Verified assets can only be
 /// imported using [verify_assets], conditional on a signature check.
 pub fn import_asset<
-    'a,
     L: Ledger,
     Meta: Serialize + DeserializeOwned + Send + Sync + Clone + PartialEq,
 >(
-    stores: &mut KeystoreStores<'a, L, Meta>,
+    stores: &mut KeystoreStores<L, Meta>,
     asset: Asset,
 ) -> Result<(), KeystoreError<L>> {
     assert!(!asset.verified());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,30 +287,15 @@ pub trait KeystoreBackend<'a, L: Ledger>: Send {
     }
 }
 
-/// Transient state derived from the persistent [LedgerState].
+/// Transient state derived from the persistent [LedgerState] and [KeystoreStores].
 pub struct KeystoreModel<
     'a,
-    L: Ledger,
+    L: 'static + Ledger,
     Backend: KeystoreBackend<'a, L>,
-    Meta: Serialize + DeserializeOwned + Send,
+    Meta: Serialize + DeserializeOwned + Send + Sync + Clone + PartialEq,
 > {
     backend: Backend,
-    atomic_store: AtomicStore,
-    meta_store: MetaStore<Meta>,
-    ledger_states: LedgerStates<'a, L>,
-    assets: Assets,
-    records: Records,
-    transactions: Transactions<L>,
-    /// Viewing accounts.
-    viewing_accounts: Accounts<L, ViewerKeyPair>,
-    /// Freezing accounts.
-    freezing_accounts: Accounts<L, FreezerKeyPair>,
-    /// Sending accounts, for spending owned records and receiving new records.
-    ///
-    /// Each public key in this set also includes a [UserAddress], which can be used to sign
-    /// outgoing transactions, as well as an encryption public key used by other users to encrypt
-    /// owner memos when sending records to this keystore.
-    sending_accounts: Accounts<L, UserKeyPair>,
+    stores: KeystoreStores<'a, L, Meta>,
     viewer_key_stream: hd::KeyTree,
     user_key_stream: hd::KeyTree,
     freezer_key_stream: hd::KeyTree,
@@ -319,8 +304,28 @@ pub struct KeystoreModel<
     _marker2: std::marker::PhantomData<L>,
 }
 
-impl<'a, L: Ledger, Backend: KeystoreBackend<'a, L>, Meta: Serialize + DeserializeOwned + Send>
-    KeystoreModel<'a, L, Backend, Meta>
+/// Storage for keystore resources.
+pub struct KeystoreStores<
+    'a,
+    L: 'static + Ledger,
+    Meta: 'a + Serialize + DeserializeOwned + Send + Sync + Clone + PartialEq,
+> {
+    atomic_store: AtomicStore,
+    meta_store: MetaStore<Meta>,
+    ledger_states: LedgerStates<'a, L>,
+    assets: Assets,
+    transactions: Transactions<L>,
+    records: Records,
+    viewing_accounts: Accounts<L, ViewerKeyPair>,
+    freezing_accounts: Accounts<L, FreezerKeyPair>,
+    sending_accounts: Accounts<L, UserKeyPair>,
+}
+
+impl<
+        'a,
+        L: 'static + Ledger,
+        Meta: 'a + Serialize + DeserializeOwned + Send + Sync + Clone + PartialEq,
+    > KeystoreStores<'a, L, Meta>
 {
     /// Access the metadata storage layer
     pub fn meta_store(&self) -> &MetaStore<Meta> {
@@ -361,27 +366,49 @@ impl<'a, L: Ledger, Backend: KeystoreBackend<'a, L>, Meta: Serialize + Deseriali
     pub fn sending_accounts_mut(&mut self) -> &mut Accounts<L, UserKeyPair> {
         &mut self.sending_accounts
     }
+
+    async fn commit(&mut self) -> Result<(), KeystoreError<L>> {
+        self.meta_store.commit();
+        self.ledger_states.commit()?;
+        self.assets.commit()?;
+        self.transactions.commit()?;
+        self.records.commit()?;
+        self.viewing_accounts.commit()?;
+        self.freezing_accounts.commit()?;
+        self.sending_accounts.commit()?;
+        self.atomic_store.commit_version()?;
+        Ok(())
+    }
 }
 
 /// Load a verified asset library with its trusted signer.
-pub fn verify_assets<'a, L: Ledger, Meta: Serialize + DeserializeOwned + Send>(
+pub fn verify_assets<
+    'a,
+    L: Ledger,
+    Meta: Serialize + DeserializeOwned + Send + Sync + Clone + PartialEq,
+>(
     model: &mut KeystoreModel<'a, L, impl KeystoreBackend<'a, L>, Meta>,
     trusted_signer: &VerKey,
     library: VerifiedAssetLibrary,
 ) -> Result<Vec<AssetDefinition>, KeystoreError<L>> {
-    model.assets.verify_assets(trusted_signer, library)
+    model.stores.assets.verify_assets(trusted_signer, library)
 }
 
 /// Import an unverified asset.
 ///
 /// Note that this function cannot be used to import verified assets. Verified assets can only be
 /// imported using [verify_assets], conditional on a signature check.
-pub fn import_asset<'a, L: Ledger, Meta: Serialize + DeserializeOwned + Send>(
+pub fn import_asset<
+    'a,
+    L: Ledger,
+    Meta: Serialize + DeserializeOwned + Send + Sync + Clone + PartialEq,
+>(
     model: &mut KeystoreModel<'a, L, impl KeystoreBackend<'a, L>, Meta>,
     asset: Asset,
 ) -> Result<(), KeystoreError<L>> {
     assert!(!asset.verified());
     model
+        .stores
         .assets
         .create_internal(
             asset.definition().clone(),
@@ -428,8 +455,8 @@ impl<L: Ledger> Default for EventSummary<L> {
 pub struct Keystore<
     'a,
     Backend: KeystoreBackend<'a, L>,
-    L: Ledger,
-    Meta: Serialize + DeserializeOwned + Send,
+    L: 'static + Ledger,
+    Meta: Serialize + DeserializeOwned + Send + Sync + Clone + PartialEq,
 > {
     // Data shared between the main thread and the event handling thread:
     //  * the trusted, persistent keystore state
@@ -493,42 +520,6 @@ impl<T: Serialize + DeserializeOwned> LoadStore for EncryptingResourceAdapter<T>
     }
 }
 
-pub struct KeystoreResources<
-    'a,
-    L: 'static + Ledger,
-    Meta: 'a + Serialize + DeserializeOwned + Send + Sync + Clone + PartialEq,
-> {
-    atomic_store: AtomicStore,
-    meta_store: MetaStore<Meta>,
-    ledger_states: LedgerStates<'a, L>,
-    assets: Assets,
-    transactions: Transactions<L>,
-    records: Records,
-    viewing_accounts: Accounts<L, ViewerKeyPair>,
-    freezing_accounts: Accounts<L, FreezerKeyPair>,
-    sending_accounts: Accounts<L, UserKeyPair>,
-}
-
-impl<
-        'a,
-        L: 'static + Ledger,
-        Meta: 'a + Serialize + DeserializeOwned + Send + Sync + Clone + PartialEq,
-    > KeystoreResources<'a, L, Meta>
-{
-    async fn commit(&mut self) -> Result<(), KeystoreError<L>> {
-        self.meta_store.commit();
-        self.ledger_states.commit()?;
-        self.assets.commit()?;
-        self.transactions.commit()?;
-        self.records.commit()?;
-        self.viewing_accounts.commit()?;
-        self.freezing_accounts.commit()?;
-        self.sending_accounts.commit()?;
-        self.atomic_store.commit_version()?;
-        Ok(())
-    }
-}
-
 // Fun fact: replacing `std::pin::Pin` with `Pin` and adding `use std::pin::Pin` causes the compiler
 // to panic where this type alias is used in `Keystore::new`. As a result, the type alias `BoxFuture`
 // from `futures::future` does not work, so we define our own.
@@ -560,7 +551,7 @@ impl<
 {
     pub fn create_stores(
         loader: &mut impl KeystoreLoader<L, Meta = Meta>,
-    ) -> Result<KeystoreResources<'a, L, Meta>, KeystoreError<L>> {
+    ) -> Result<KeystoreStores<'a, L, Meta>, KeystoreError<L>> {
         let mut atomic_loader = AtomicStoreLoader::load(&loader.location(), "keystore").unwrap();
         let file_fill_size = 1024;
         let meta_store = MetaStore::new(loader, &mut atomic_loader)?;
@@ -593,7 +584,7 @@ impl<
             file_fill_size,
         )?;
         let atomic_store = AtomicStore::open(atomic_loader)?;
-        Ok(KeystoreResources {
+        Ok(KeystoreStores {
             atomic_store,
             meta_store,
             ledger_states,
@@ -621,18 +612,18 @@ impl<
         mut backend: Backend,
         loader: &mut impl KeystoreLoader<L, Meta = Meta>,
     ) -> BoxFuture<'a, Result<Keystore<'a, Backend, L, Meta>, KeystoreError<L>>> {
-        let mut resources = Self::create_stores(loader).unwrap();
+        let mut stores = Self::create_stores(loader).unwrap();
         Box::pin(async move {
-            let state = if resources.meta_store.exists() {
-                resources.ledger_states.load()?
+            let state = if stores.meta_store.exists() {
+                stores.ledger_states.load()?
             } else {
                 let state: LedgerState<'a, L> = backend.create().await?;
-                resources.meta_store.create().await?;
-                resources.ledger_states.update(&state)?;
+                stores.meta_store.create().await?;
+                stores.ledger_states.update(&state)?;
                 state
             };
-            resources.commit().await?;
-            Self::new_impl(backend, resources, state).await
+            stores.commit().await?;
+            Self::new_impl(backend, stores, state).await
         })
     }
 
@@ -645,9 +636,9 @@ impl<
         freezing_key: Option<(FreezerKeyPair, String)>,
         sending_key: Option<(UserKeyPair, String)>,
     ) -> BoxFuture<'a, Result<Keystore<'a, Backend, L, Meta>, KeystoreError<L>>> {
-        let mut resources = Self::create_stores(loader).unwrap();
+        let mut stores = Self::create_stores(loader).unwrap();
         if let Some((key, description)) = viewing_key {
-            resources
+            stores
                 .viewing_accounts
                 .create(key, None)
                 .unwrap()
@@ -656,7 +647,7 @@ impl<
                 .unwrap();
         }
         if let Some((key, description)) = freezing_key {
-            resources
+            stores
                 .freezing_accounts
                 .create(key, None)
                 .unwrap()
@@ -665,7 +656,7 @@ impl<
                 .unwrap();
         }
         if let Some((key, description)) = sending_key {
-            resources
+            stores
                 .sending_accounts
                 .create(key, None)
                 .unwrap()
@@ -674,21 +665,21 @@ impl<
                 .unwrap();
         }
         Box::pin(async move {
-            resources.meta_store.create().await?;
-            resources.ledger_states.update(&state)?;
-            resources.commit().await?;
-            Self::new_impl(backend, resources, state).await
+            stores.meta_store.create().await?;
+            stores.ledger_states.update(&state)?;
+            stores.commit().await?;
+            Self::new_impl(backend, stores, state).await
         })
     }
 
     async fn new_impl(
         backend: Backend,
-        resources: KeystoreResources<'a, L, Meta>,
+        stores: KeystoreStores<'a, L, Meta>,
         state: LedgerState<'a, L>,
     ) -> Result<Keystore<'a, Backend, L, Meta>, KeystoreError<L>> {
         let mut events = backend.subscribe(state.now(), None).await;
         let mut key_scans = vec![];
-        for account in resources.viewing_accounts.iter() {
+        for account in stores.viewing_accounts.iter() {
             if let Some(scan) = &account.scan() {
                 key_scans.push((
                     scan.address(),
@@ -696,18 +687,20 @@ impl<
                 ));
             }
         }
-        let key_tree = resources.meta_store.key_stream();
+        let key_tree = stores.meta_store.key_stream();
         let mut model = KeystoreModel {
             backend,
-            atomic_store: resources.atomic_store,
-            meta_store: resources.meta_store,
-            ledger_states: resources.ledger_states,
-            assets: resources.assets,
-            transactions: resources.transactions,
-            records: resources.records,
-            viewing_accounts: resources.viewing_accounts,
-            freezing_accounts: resources.freezing_accounts,
-            sending_accounts: resources.sending_accounts,
+            stores: KeystoreStores {
+                atomic_store: stores.atomic_store,
+                meta_store: stores.meta_store,
+                ledger_states: stores.ledger_states,
+                assets: stores.assets,
+                transactions: stores.transactions,
+                records: stores.records,
+                viewing_accounts: stores.viewing_accounts,
+                freezing_accounts: stores.freezing_accounts,
+                sending_accounts: stores.sending_accounts,
+            },
             viewer_key_stream: key_tree.derive_sub_tree("viewer".as_bytes()),
             freezer_key_stream: key_tree.derive_sub_tree("freezer".as_bytes()),
             user_key_stream: key_tree.derive_sub_tree("user".as_bytes()),
@@ -716,7 +709,7 @@ impl<
             _marker2: Default::default(),
         };
         // Ensure the native asset type is always recognized.
-        model.assets_mut().create_native()?;
+        model.stores.assets_mut().create_native()?;
 
         let mutex = Arc::new(KeystoreSharedStateRwLock::new(
             state,
@@ -787,25 +780,25 @@ impl<
     /// Get the viewing public keys.
     pub async fn viewing_pub_keys(&self) -> Vec<ViewerPubKey> {
         let KeystoreSharedState { model, .. } = &*self.read().await;
-        model.viewing_accounts.iter_pub_keys().collect()
+        model.stores.viewing_accounts.iter_pub_keys().collect()
     }
 
     /// Get the freezing public keys.
     pub async fn freezing_pub_keys(&self) -> Vec<FreezerPubKey> {
         let KeystoreSharedState { model, .. } = &*self.read().await;
-        model.freezing_accounts.iter_pub_keys().collect()
+        model.stores.freezing_accounts.iter_pub_keys().collect()
     }
 
     /// Get the sending addresses.
     pub async fn sending_addresses(&self) -> Vec<UserAddress> {
         let KeystoreSharedState { model, .. } = &*self.read().await;
-        model.sending_accounts.iter_pub_keys().collect()
+        model.stores.sending_accounts.iter_pub_keys().collect()
     }
 
     /// Get the sending keys.
     pub async fn sending_keys(&self) -> Vec<UserKeyPair> {
         let KeystoreSharedState { model, .. } = &*self.read().await;
-        model.sending_accounts.iter_keys().collect()
+        model.stores.sending_accounts.iter_keys().collect()
     }
 
     /// Get the viewing account by the public key.
@@ -814,7 +807,7 @@ impl<
         pub_key: &ViewerPubKey,
     ) -> Result<Account<L, ViewerKeyPair>, KeystoreError<L>> {
         let KeystoreSharedState { model, .. } = &*self.read().await;
-        model.viewing_accounts.get(pub_key)
+        model.stores.viewing_accounts.get(pub_key)
     }
 
     /// Get the freezing account by the public key.
@@ -823,7 +816,7 @@ impl<
         pub_key: &FreezerPubKey,
     ) -> Result<Account<L, FreezerKeyPair>, KeystoreError<L>> {
         let KeystoreSharedState { model, .. } = &*self.read().await;
-        model.freezing_accounts.get(pub_key)
+        model.stores.freezing_accounts.get(pub_key)
     }
 
     /// Get the sending account by the address.
@@ -832,7 +825,7 @@ impl<
         address: &UserAddress,
     ) -> Result<Account<L, UserKeyPair>, KeystoreError<L>> {
         let KeystoreSharedState { model, .. } = &*self.read().await;
-        model.sending_accounts.get(address)
+        model.stores.sending_accounts.get(address)
     }
 
     /// Compute the spendable balance of the given asset owned by the given addresses.
@@ -840,7 +833,7 @@ impl<
         let KeystoreSharedState { state, model, .. } = &*self.read().await;
         state.balance(
             model,
-            model.sending_accounts.iter_pub_keys(),
+            model.stores.sending_accounts.iter_pub_keys(),
             asset,
             FreezeFlag::Unfrozen,
         )
@@ -849,7 +842,7 @@ impl<
     /// Compute the spendable balance of the given asset owned by the given address.
     pub async fn balance_breakdown(&self, address: &UserAddress, asset: &AssetCode) -> U256 {
         let KeystoreSharedState { state, model, .. } = &*self.read().await;
-        match model.sending_accounts.get(address) {
+        match model.stores.sending_accounts.get(address) {
             Ok(account) => {
                 state.balance_breakdown(model, &account.pub_key(), asset, FreezeFlag::Unfrozen)
             }
@@ -860,7 +853,7 @@ impl<
     /// Compute the balance frozen records of the given asset type owned by the given address.
     pub async fn frozen_balance_breakdown(&self, address: &UserAddress, asset: &AssetCode) -> U256 {
         let KeystoreSharedState { state, model, .. } = &*self.read().await;
-        match model.sending_accounts.get(address) {
+        match model.stores.sending_accounts.get(address) {
             Ok(account) => {
                 state.balance_breakdown(model, &account.pub_key(), asset, FreezeFlag::Frozen)
             }
@@ -871,19 +864,19 @@ impl<
     /// List records owned or viewable by this keystore.
     pub async fn records(&self) -> Vec<Record> {
         let KeystoreSharedState { model, .. } = &*self.read().await;
-        model.records.iter().collect::<Vec<_>>()
+        model.stores.records.iter().collect::<Vec<_>>()
     }
 
     /// List assets discovered or imported by this keystore.
     pub async fn assets(&self) -> Vec<Asset> {
         let KeystoreSharedState { model, .. } = &*self.read().await;
-        model.assets()
+        model.stores.assets()
     }
 
     /// Get details about an asset type using its code.
     pub async fn asset(&self, code: AssetCode) -> Option<Asset> {
         let KeystoreSharedState { model, .. } = &*self.read().await;
-        model.asset(&code).ok()
+        model.stores.asset(&code).ok()
     }
 
     /// List past transactions involving this keystore.
@@ -894,7 +887,7 @@ impl<
     {
         Box::pin(async move {
             let KeystoreSharedState { model, .. } = &*self.read().await;
-            let mut history = model.transactions.iter().collect::<Vec<_>>();
+            let mut history = model.stores.transactions.iter().collect::<Vec<_>>();
             history.sort_by_key(|txn| *txn.created_time());
             Ok(history)
         })
@@ -952,9 +945,9 @@ impl<
                 async move {
                     let sender_key_pairs = match sender {
                         Some(addr) => {
-                            vec![model.sending_accounts.get(addr)?.key().clone()]
+                            vec![model.stores.sending_accounts.get(addr)?.key().clone()]
                         }
-                        None => model.sending_accounts.iter_keys().collect(),
+                        None => model.stores.sending_accounts.iter_keys().collect(),
                     };
                     let spec = TransferSpec {
                         sender_key_pairs: &sender_key_pairs,
@@ -1408,7 +1401,7 @@ impl<
         uid: &TransactionUID<L>,
     ) -> Result<TransactionStatus, KeystoreError<L>> {
         let KeystoreSharedState { model, .. } = &*self.read().await;
-        Ok(model.transactions.get(uid)?.status())
+        Ok(model.stores.transactions.get(uid)?.status())
     }
 
     /// A future which completes when the transaction is finalized (committed or rejected).
@@ -1429,7 +1422,7 @@ impl<
                          txn_subscribers,
                          ..
                      }| async move {
-                        let status = model.transactions.get(uid)?.status();
+                        let status = model.stores.transactions.get(uid)?.status();
                         if status.is_final() {
                             Ok(Ok(status))
                         } else {
@@ -1568,7 +1561,7 @@ impl<
         self.write()
             .await
             .update(|KeystoreSharedState { model, .. }| async move {
-                model.assets_mut().insert(asset)?.save()?;
+                model.stores.assets_mut().insert(asset)?.save()?;
                 Ok(())
             })
             .await
@@ -1588,6 +1581,7 @@ impl<
             .await
             .update(|KeystoreSharedState { model, .. }| async move {
                 model
+                    .stores
                     .assets_mut()
                     .create(definition, mint_info)?
                     .set_name(name)
@@ -1609,6 +1603,7 @@ impl<
             .await
             .update(|KeystoreSharedState { model, .. }| async move {
                 model
+                    .stores
                     .assets_mut()
                     .create_native()?
                     .set_icon(icon)
@@ -1623,7 +1618,7 @@ async fn update_ledger<
     'a,
     L: 'static + Ledger,
     Backend: KeystoreBackend<'a, L>,
-    Meta: Send + DeserializeOwned + Serialize,
+    Meta: Send + DeserializeOwned + Serialize + Sync + Clone + PartialEq,
 >(
     event: LedgerEvent<L>,
     source: EventSource,
@@ -1666,7 +1661,7 @@ async fn update_key_scan<
     'a,
     L: 'static + Ledger,
     Backend: KeystoreBackend<'a, L>,
-    Meta: Send + DeserializeOwned + Serialize,
+    Meta: Send + DeserializeOwned + Serialize + Sync + Clone + PartialEq,
 >(
     address: &UserAddress,
     event: LedgerEvent<L>,
@@ -1681,6 +1676,7 @@ async fn update_key_scan<
     } = shared_state;
 
     let finished = match model
+        .stores
         .sending_accounts
         .get_mut(address)
         .unwrap()
@@ -1695,7 +1691,7 @@ async fn update_key_scan<
                         tracing::error!("Error saving records from key scan {}: {}", address, err);
                     }
                     for (uid, t) in history {
-                        model.transactions.create(uid, t)?;
+                        model.stores.transactions.create(uid, t)?;
                     }
 
                     // Signal anyone waiting for a notification that this scan finished.
@@ -1713,7 +1709,7 @@ async fn update_key_scan<
         _ => false,
     };
 
-    model.ledger_states.update_dynamic(state)?;
+    model.stores.ledger_states.update_dynamic(state)?;
     Ok(finished)
 }
 

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -5,7 +5,7 @@
 // This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! Ledger-agnostic implementation of [KeystoreStorage].
+//! Ledger-agnostic implementation of [KeystoreStores].
 use crate::{hd::KeyTree, loader::KeystoreLoader, EncryptingResourceAdapter, KeystoreError};
 use atomic_store::{load_store::BincodeLoadStore, AtomicStoreLoader, RollingLog};
 use reef::*;

--- a/src/state.rs
+++ b/src/state.rs
@@ -31,30 +31,12 @@ impl<
         Meta: Serialize + DeserializeOwned + Send + Sync + Clone + PartialEq,
     > KeystoreSharedState<'a, L, Backend, Meta>
 {
-    async fn commit(&mut self) -> Result<(), KeystoreError<L>> {
-        self.model.stores.meta_store.commit();
-        self.model.stores.ledger_states.commit()?;
-        self.model.stores.assets.commit()?;
-        self.model.stores.transactions.commit()?;
-        self.model.stores.records.commit()?;
-        self.model.stores.viewing_accounts.commit()?;
-        self.model.stores.freezing_accounts.commit()?;
-        self.model.stores.sending_accounts.commit()?;
-        self.model
-            .stores
-            .atomic_store
-            .commit_version()
-            .map_err(KeystoreError::from)
+    fn commit(&mut self) -> Result<(), KeystoreError<L>> {
+        self.model.stores.commit()
     }
 
     async fn revert(&mut self) -> Result<(), KeystoreError<L>> {
-        self.model.stores.assets.revert()?;
-        self.model.stores.transactions.revert()?;
-        self.model.stores.viewing_accounts.revert()?;
-        self.model.stores.freezing_accounts.revert()?;
-        self.model.stores.sending_accounts.revert()?;
-        self.model.stores.meta_store.revert().await;
-        Ok(())
+        self.model.stores.revert().await
     }
 }
 
@@ -287,7 +269,7 @@ impl<
             if self.failed {
                 self.guard.revert().await.unwrap();
             } else {
-                self.guard.commit().await.unwrap();
+                self.guard.commit().unwrap();
             }
         });
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -13,9 +13,9 @@ use std::collections::HashMap;
 /// Keystore state which is shared with event handling threads.
 pub struct KeystoreSharedState<
     'a,
-    L: Ledger,
+    L: 'static + Ledger,
     Backend: KeystoreBackend<'a, L>,
-    Meta: Serialize + DeserializeOwned + Send,
+    Meta: Serialize + DeserializeOwned + Send + Sync + Clone + PartialEq,
 > {
     pub(crate) state: LedgerState<'a, L>,
     pub(crate) model: KeystoreModel<'a, L, Backend, Meta>,
@@ -28,37 +28,42 @@ impl<
         'a,
         L: 'static + Ledger,
         Backend: KeystoreBackend<'a, L>,
-        Meta: Serialize + DeserializeOwned + Send,
+        Meta: Serialize + DeserializeOwned + Send + Sync + Clone + PartialEq,
     > KeystoreSharedState<'a, L, Backend, Meta>
 {
     async fn commit(&mut self) -> Result<(), KeystoreError<L>> {
-        self.model.meta_store.commit();
-        self.model.ledger_states.commit()?;
-        self.model.assets.commit()?;
-        self.model.transactions.commit()?;
-        self.model.records.commit()?;
-        self.model.viewing_accounts.commit()?;
-        self.model.freezing_accounts.commit()?;
-        self.model.sending_accounts.commit()?;
+        self.model.stores.meta_store.commit();
+        self.model.stores.ledger_states.commit()?;
+        self.model.stores.assets.commit()?;
+        self.model.stores.transactions.commit()?;
+        self.model.stores.records.commit()?;
+        self.model.stores.viewing_accounts.commit()?;
+        self.model.stores.freezing_accounts.commit()?;
+        self.model.stores.sending_accounts.commit()?;
         self.model
+            .stores
             .atomic_store
             .commit_version()
             .map_err(KeystoreError::from)
     }
 
     async fn revert(&mut self) -> Result<(), KeystoreError<L>> {
-        self.model.assets.revert()?;
-        self.model.transactions.revert()?;
-        self.model.viewing_accounts.revert()?;
-        self.model.freezing_accounts.revert()?;
-        self.model.sending_accounts.revert()?;
-        self.model.meta_store.revert().await;
+        self.model.stores.assets.revert()?;
+        self.model.stores.transactions.revert()?;
+        self.model.stores.viewing_accounts.revert()?;
+        self.model.stores.freezing_accounts.revert()?;
+        self.model.stores.sending_accounts.revert()?;
+        self.model.stores.meta_store.revert().await;
         Ok(())
     }
 }
 
-impl<'a, L: Ledger, Backend: KeystoreBackend<'a, L>, Meta: Serialize + DeserializeOwned + Send>
-    KeystoreSharedState<'a, L, Backend, Meta>
+impl<
+        'a,
+        L: Ledger,
+        Backend: KeystoreBackend<'a, L>,
+        Meta: Serialize + DeserializeOwned + Send + Sync + Clone + PartialEq,
+    > KeystoreSharedState<'a, L, Backend, Meta>
 {
     pub fn new(
         state: LedgerState<'a, L>,
@@ -94,16 +99,16 @@ impl<'a, L: Ledger, Backend: KeystoreBackend<'a, L>, Meta: Serialize + Deseriali
 /// A read-write lock where writes must go through atomic storage transactions.
 pub struct KeystoreSharedStateRwLock<
     'a,
-    L: Ledger,
+    L: 'static + Ledger,
     Backend: KeystoreBackend<'a, L>,
-    Meta: Send + Serialize + DeserializeOwned,
+    Meta: Send + Serialize + DeserializeOwned + Sync + Clone + PartialEq,
 >(RwLock<KeystoreSharedState<'a, L, Backend, Meta>>);
 
 impl<
         'a,
         L: 'static + Ledger,
         Backend: KeystoreBackend<'a, L>,
-        Meta: Send + Serialize + DeserializeOwned,
+        Meta: Send + Serialize + DeserializeOwned + Sync + Clone + PartialEq,
     > KeystoreSharedStateRwLock<'a, L, Backend, Meta>
 {
     pub fn new(
@@ -149,7 +154,7 @@ pub struct KeystoreSharedStateWriteGuard<
     'a,
     L: 'static + Ledger,
     Backend: KeystoreBackend<'a, L>,
-    Meta: Send + Serialize + DeserializeOwned,
+    Meta: Send + Serialize + DeserializeOwned + Sync + Clone + PartialEq,
 > {
     guard: RwLockWriteGuard<'l, KeystoreSharedState<'a, L, Backend, Meta>>,
     failed: bool,
@@ -160,7 +165,7 @@ impl<
         'a,
         L: 'static + Ledger,
         Backend: KeystoreBackend<'a, L>,
-        Meta: Send + Serialize + DeserializeOwned,
+        Meta: Send + Serialize + DeserializeOwned + Sync + Clone + PartialEq,
     > KeystoreSharedStateWriteGuard<'l, 'a, L, Backend, Meta>
 {
     async fn new(
@@ -274,7 +279,7 @@ impl<
         'a,
         L: 'static + Ledger,
         Backend: KeystoreBackend<'a, L>,
-        Meta: Send + Serialize + DeserializeOwned,
+        Meta: Send + Serialize + DeserializeOwned + Sync + Clone + PartialEq,
     > Drop for KeystoreSharedStateWriteGuard<'l, 'a, L, Backend, Meta>
 {
     fn drop(&mut self) {

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -529,7 +529,7 @@ pub trait SystemUnderTest<'a>: Default + Send + Sync {
     ) {
         for (keystore, _, _) in keystores {
             let KeystoreSharedState { state, model, .. } = &*keystore.mutex.read().await;
-            let loaded = &model.ledger_states.load().unwrap();
+            let loaded = &model.stores.ledger_states.load().unwrap();
             assert_keystore_states_eq(&state, &loaded);
         }
     }

--- a/src/testing/tests.rs
+++ b/src/testing/tests.rs
@@ -1946,10 +1946,11 @@ pub mod generic_keystore_tests {
                 .await
                 .update(|KeystoreSharedState { model, .. }| async move {
                     let key = model
+                        .stores
                         .meta_store
                         .key_stream()
                         .derive_sub_tree("user".as_bytes())
-                        .derive_user_key_pair(&model.sending_accounts.index().to_le_bytes());
+                        .derive_user_key_pair(&model.stores.sending_accounts.index().to_le_bytes());
                     model.backend.register_user_key(&key).await.unwrap();
                     Ok(key)
                 })


### PR DESCRIPTION
- Implements `KeystoreStores` to store all resources, which can be created by `create_stores`.
- Replaces resources in `KeystoreModel` with `KeystoreStores` and updates callers.

Closes https://github.com/EspressoSystems/seahorse/issues/227.