### PR TITLE
Use `spawn_blocking` for blocking IO in CLI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/espressosystems/devops-rust:1.63
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/espressosystems/devops-rust:1.63
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   code-coverage:
-    runs-on: [self-hosted, X64]
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/espressosystems/nix:2.8.1
       volumes:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   code-coverage:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, X64]
     container:
       image: ghcr.io/espressosystems/nix:2.8.1
       volumes:

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build:
-    runs-on: [self-hosted, X64]
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/espressosystems/devops-rust:1.63
     steps:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,7 +368,7 @@ impl<
     }
 
     fn commit(&mut self) -> Result<(), KeystoreError<L>> {
-        self.meta_store.commit();
+        self.meta_store.commit()?;
         self.ledger_states.commit()?;
         self.assets.commit()?;
         self.transactions.commit()?;
@@ -380,8 +380,8 @@ impl<
         Ok(())
     }
 
-    async fn revert(&mut self) -> Result<(), KeystoreError<L>> {
-        self.meta_store.revert().await;
+    fn revert(&mut self) -> Result<(), KeystoreError<L>> {
+        self.meta_store.revert()?;
         self.ledger_states.revert()?;
         self.assets.revert()?;
         self.transactions.revert()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -558,12 +558,12 @@ impl<
         Meta: 'a + Serialize + DeserializeOwned + Send + Sync + Clone + PartialEq,
     > Keystore<'a, Backend, L, Meta>
 {
-    pub fn create_stores(
+    pub async fn create_stores(
         loader: &mut impl KeystoreLoader<L, Meta = Meta>,
     ) -> Result<KeystoreStores<'a, L, Meta>, KeystoreError<L>> {
         let mut atomic_loader = AtomicStoreLoader::load(&loader.location(), "keystore").unwrap();
         let file_fill_size = 1024;
-        let meta_store = MetaStore::new(loader, &mut atomic_loader)?;
+        let meta_store = MetaStore::new(loader, &mut atomic_loader).await?;
         let adaptor = meta_store.encrypting_storage_adapter::<()>();
         let ledger_states = LedgerStates::new(
             &mut atomic_loader,
@@ -617,12 +617,15 @@ impl<
     // manually write out the opaque return type so that we can explicitly add the `Send` bound. The
     // difference is that we use dynamic type erasure (Pin<Box<dyn Future>>) instead of static type
     // erasure. I don't know why this doesn't crash the compiler, but it doesn't.
-    pub fn new(
+    pub fn new<'l>(
         mut backend: Backend,
-        loader: &mut impl KeystoreLoader<L, Meta = Meta>,
-    ) -> BoxFuture<'a, Result<Keystore<'a, Backend, L, Meta>, KeystoreError<L>>> {
-        let mut stores = Self::create_stores(loader).unwrap();
+        loader: &'l mut (impl KeystoreLoader<L, Meta = Meta> + Send),
+    ) -> BoxFuture<'l, Result<Keystore<'a, Backend, L, Meta>, KeystoreError<L>>>
+    where
+        'a: 'l,
+    {
         Box::pin(async move {
+            let mut stores = Self::create_stores(loader).await?;
             let state = if stores.meta_store.exists() {
                 stores.ledger_states.load()?
             } else {
@@ -637,43 +640,47 @@ impl<
     }
 
     #[cfg(any(test, bench, feature = "testing"))]
-    pub fn with_state_and_keys(
+    pub fn with_state_and_keys<'l>(
         backend: Backend,
-        loader: &mut (impl 'a + KeystoreLoader<L, Meta = Meta>),
+        loader: &'l mut (impl 'a + KeystoreLoader<L, Meta = Meta> + Send),
         state: LedgerState<'a, L>,
         viewing_key: Option<(ViewerKeyPair, String)>,
         freezing_key: Option<(FreezerKeyPair, String)>,
         sending_key: Option<(UserKeyPair, String)>,
-    ) -> BoxFuture<'a, Result<Keystore<'a, Backend, L, Meta>, KeystoreError<L>>> {
-        let mut stores = Self::create_stores(loader).unwrap();
-        if let Some((key, description)) = viewing_key {
-            stores
-                .viewing_accounts
-                .create(key, None)
-                .unwrap()
-                .with_description(description)
-                .save()
-                .unwrap();
-        }
-        if let Some((key, description)) = freezing_key {
-            stores
-                .freezing_accounts
-                .create(key, None)
-                .unwrap()
-                .with_description(description)
-                .save()
-                .unwrap();
-        }
-        if let Some((key, description)) = sending_key {
-            stores
-                .sending_accounts
-                .create(key, None)
-                .unwrap()
-                .with_description(description)
-                .save()
-                .unwrap();
-        }
+    ) -> BoxFuture<'l, Result<Keystore<'a, Backend, L, Meta>, KeystoreError<L>>>
+    where
+        'a: 'l,
+    {
         Box::pin(async move {
+            let mut stores = Self::create_stores(loader).await?;
+            if let Some((key, description)) = viewing_key {
+                stores
+                    .viewing_accounts
+                    .create(key, None)
+                    .unwrap()
+                    .with_description(description)
+                    .save()
+                    .unwrap();
+            }
+            if let Some((key, description)) = freezing_key {
+                stores
+                    .freezing_accounts
+                    .create(key, None)
+                    .unwrap()
+                    .with_description(description)
+                    .save()
+                    .unwrap();
+            }
+            if let Some((key, description)) = sending_key {
+                stores
+                    .sending_accounts
+                    .create(key, None)
+                    .unwrap()
+                    .with_description(description)
+                    .save()
+                    .unwrap();
+            }
+
             stores.meta_store.create().await?;
             stores.ledger_states.update(&state)?;
             stores.commit()?;

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -21,6 +21,7 @@ use crate::{
     hd::{KeyTree, Mnemonic, Salt},
     EncryptionSnafu, KeySnafu, KeystoreError, Ledger,
 };
+use async_trait::async_trait;
 use rand_chacha::{
     rand_core::{RngCore, SeedableRng},
     ChaChaRng,
@@ -42,6 +43,7 @@ pub use interactive::InteractiveLoader;
 pub use login::LoginLoader;
 pub use recovery::RecoveryLoader;
 
+#[async_trait]
 pub trait KeystoreLoader<L: Ledger> {
     /// Metadata about a keystore which is always stored unencrypted.
     ///
@@ -64,7 +66,7 @@ pub trait KeystoreLoader<L: Ledger> {
     /// will create the metadata for a new keystore and return it, along with the key tree to use
     /// when deriving keys for the new keystore. The caller should persist the new metadata in
     /// `self.location()`.
-    fn create(&mut self) -> Result<(Self::Meta, KeyTree), KeystoreError<L>>;
+    async fn create(&mut self) -> Result<(Self::Meta, KeyTree), KeystoreError<L>>;
 
     /// Load an existing keystore.
     ///
@@ -79,7 +81,7 @@ pub trait KeystoreLoader<L: Ledger> {
     /// `self.location()`.
     ///
     /// If [load](Self::load) fails, it will not change `meta`.
-    fn load(&mut self, meta: &mut Self::Meta) -> Result<KeyTree, KeystoreError<L>>;
+    async fn load(&mut self, meta: &mut Self::Meta) -> Result<KeyTree, KeystoreError<L>>;
 }
 
 /// Metadata that supports login with a password and backup/recovery with a mnemonic.

--- a/src/loader/create.rs
+++ b/src/loader/create.rs
@@ -10,6 +10,7 @@ use crate::{
     loader::{KeystoreLoader, MnemonicPasswordLogin},
     KeystoreError,
 };
+use async_trait::async_trait;
 use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
 use reef::Ledger;
 use std::path::PathBuf;
@@ -56,6 +57,7 @@ impl CreateLoader {
     }
 }
 
+#[async_trait]
 impl<L: Ledger> KeystoreLoader<L> for CreateLoader {
     type Meta = MnemonicPasswordLogin;
 
@@ -63,14 +65,14 @@ impl<L: Ledger> KeystoreLoader<L> for CreateLoader {
         self.dir.clone()
     }
 
-    fn create(&mut self) -> Result<(Self::Meta, KeyTree), KeystoreError<L>> {
+    async fn create(&mut self) -> Result<(Self::Meta, KeyTree), KeystoreError<L>> {
         let meta =
             MnemonicPasswordLogin::new(&mut self.rng, &self.mnemonic, self.password.as_bytes())?;
         let key = KeyTree::from_mnemonic(&self.mnemonic);
         Ok((meta, key))
     }
 
-    fn load(&mut self, meta: &mut Self::Meta) -> Result<KeyTree, KeystoreError<L>> {
+    async fn load(&mut self, meta: &mut Self::Meta) -> Result<KeyTree, KeystoreError<L>> {
         if self.exclusive {
             return Err(KeystoreError::Failed {
                 msg: String::from("using an exclusive CreateLoader with an existing keystore"),

--- a/src/loader/login.rs
+++ b/src/loader/login.rs
@@ -10,6 +10,7 @@ use crate::{
     loader::{KeystoreLoader, MnemonicPasswordLogin},
     KeystoreError,
 };
+use async_trait::async_trait;
 use reef::Ledger;
 use std::path::PathBuf;
 
@@ -28,6 +29,7 @@ impl LoginLoader {
     }
 }
 
+#[async_trait]
 impl<L: Ledger> KeystoreLoader<L> for LoginLoader {
     type Meta = MnemonicPasswordLogin;
 
@@ -35,13 +37,13 @@ impl<L: Ledger> KeystoreLoader<L> for LoginLoader {
         self.dir.clone()
     }
 
-    fn create(&mut self) -> Result<(Self::Meta, KeyTree), KeystoreError<L>> {
+    async fn create(&mut self) -> Result<(Self::Meta, KeyTree), KeystoreError<L>> {
         Err(KeystoreError::Failed {
             msg: String::from("LoginLoader does not support creating a new keystore"),
         })
     }
 
-    fn load(&mut self, meta: &mut Self::Meta) -> Result<KeyTree, KeystoreError<L>> {
+    async fn load(&mut self, meta: &mut Self::Meta) -> Result<KeyTree, KeystoreError<L>> {
         let mnemonic = meta
             .decrypt_mnemonic(self.password.as_bytes())
             .ok_or_else(|| KeystoreError::Failed {

--- a/src/loader/recovery.rs
+++ b/src/loader/recovery.rs
@@ -10,6 +10,7 @@ use crate::{
     loader::{KeystoreLoader, MnemonicPasswordLogin},
     KeystoreError,
 };
+use async_trait::async_trait;
 use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
 use reef::Ledger;
 use std::path::PathBuf;
@@ -52,6 +53,7 @@ impl RecoveryLoader {
     }
 }
 
+#[async_trait]
 impl<L: Ledger> KeystoreLoader<L> for RecoveryLoader {
     type Meta = MnemonicPasswordLogin;
 
@@ -59,7 +61,7 @@ impl<L: Ledger> KeystoreLoader<L> for RecoveryLoader {
         self.dir.clone()
     }
 
-    fn create(&mut self) -> Result<(Self::Meta, KeyTree), KeystoreError<L>> {
+    async fn create(&mut self) -> Result<(Self::Meta, KeyTree), KeystoreError<L>> {
         let meta = MnemonicPasswordLogin::new(
             &mut self.rng,
             &self.mnemonic,
@@ -69,7 +71,7 @@ impl<L: Ledger> KeystoreLoader<L> for RecoveryLoader {
         Ok((meta, key))
     }
 
-    fn load(&mut self, meta: &mut Self::Meta) -> Result<KeyTree, KeystoreError<L>> {
+    async fn load(&mut self, meta: &mut Self::Meta) -> Result<KeyTree, KeystoreError<L>> {
         meta.set_password(&mut self.rng, &self.mnemonic, self.new_password.as_bytes())?;
         Ok(KeyTree::from_mnemonic(&self.mnemonic))
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -35,8 +35,8 @@ impl<
         self.model.stores.commit()
     }
 
-    async fn revert(&mut self) -> Result<(), KeystoreError<L>> {
-        self.model.stores.revert().await
+    fn revert(&mut self) -> Result<(), KeystoreError<L>> {
+        self.model.stores.revert()
     }
 }
 
@@ -265,12 +265,10 @@ impl<
     > Drop for KeystoreSharedStateWriteGuard<'l, 'a, L, Backend, Meta>
 {
     fn drop(&mut self) {
-        async_std::task::block_on(async move {
-            if self.failed {
-                self.guard.revert().await.unwrap();
-            } else {
-                self.guard.commit().unwrap();
-            }
-        });
+        if self.failed {
+            self.guard.revert().unwrap();
+        } else {
+            self.guard.commit().unwrap();
+        }
     }
 }

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -17,6 +17,7 @@
 /// test suite for the generic keystore interface, which is instantiated for each ledger/backend.
 use super::*;
 use async_std::sync::{Arc, Mutex};
+use async_trait::async_trait;
 use chrono::Local;
 use futures::{channel::mpsc, stream::iter};
 use hd::KeyTree;
@@ -40,6 +41,7 @@ pub struct TrivialKeystoreLoader {
     pub key_tree: KeyTree,
 }
 
+#[async_trait]
 impl<L: Ledger> KeystoreLoader<L> for TrivialKeystoreLoader {
     type Meta = ();
 
@@ -47,11 +49,11 @@ impl<L: Ledger> KeystoreLoader<L> for TrivialKeystoreLoader {
         self.dir.clone()
     }
 
-    fn create(&mut self) -> Result<((), KeyTree), KeystoreError<L>> {
+    async fn create(&mut self) -> Result<((), KeyTree), KeystoreError<L>> {
         Ok(((), self.key_tree.clone()))
     }
 
-    fn load(&mut self, _meta: &mut ()) -> Result<KeyTree, KeystoreError<L>> {
+    async fn load(&mut self, _meta: &mut ()) -> Result<KeyTree, KeystoreError<L>> {
         Ok(self.key_tree.clone())
     }
 }


### PR DESCRIPTION
This should stop the tests with multiple clients from blocking all the executor threads, allowing us to run on just 1 or 2 cores (e.g. the GitHub runners).